### PR TITLE
Add native GitHub Copilot compatibility to the Rust CLI

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "pulldown-cmark",
  "runtime",
  "rustyline",
+ "serde",
  "serde_json",
  "syntect",
  "tokio",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 publish = false
 
 [workspace.dependencies]
+serde = { version = "1", features = ["derive"] }
 lsp-types = "0.97"
 serde_json = "1"
 

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -1,5 +1,6 @@
 use crate::error::ApiError;
 use crate::providers::claw_provider::{self, AuthSource, ClawApiClient};
+use crate::providers::github_copilot;
 use crate::providers::openai_compat::{self, OpenAiCompatClient, OpenAiCompatConfig};
 use crate::providers::{self, Provider, ProviderKind};
 use crate::types::{MessageRequest, MessageResponse, StreamEvent};
@@ -21,6 +22,7 @@ async fn stream_via_provider<P: Provider>(
 #[derive(Debug, Clone)]
 pub enum ProviderClient {
     ClawApi(ClawApiClient),
+    GithubCopilot(OpenAiCompatClient),
     Xai(OpenAiCompatClient),
     OpenAi(OpenAiCompatClient),
 }
@@ -40,6 +42,9 @@ impl ProviderClient {
                 Some(auth) => ClawApiClient::from_auth(auth),
                 None => ClawApiClient::from_env()?,
             })),
+            ProviderKind::GithubCopilot => {
+                Ok(Self::GithubCopilot(github_copilot::client_from_env()?))
+            }
             ProviderKind::Xai => Ok(Self::Xai(OpenAiCompatClient::from_env(
                 OpenAiCompatConfig::xai(),
             )?)),
@@ -53,6 +58,7 @@ impl ProviderClient {
     pub const fn provider_kind(&self) -> ProviderKind {
         match self {
             Self::ClawApi(_) => ProviderKind::ClawApi,
+            Self::GithubCopilot(_) => ProviderKind::GithubCopilot,
             Self::Xai(_) => ProviderKind::Xai,
             Self::OpenAi(_) => ProviderKind::OpenAi,
         }
@@ -64,7 +70,9 @@ impl ProviderClient {
     ) -> Result<MessageResponse, ApiError> {
         match self {
             Self::ClawApi(client) => send_via_provider(client, request).await,
-            Self::Xai(client) | Self::OpenAi(client) => send_via_provider(client, request).await,
+            Self::GithubCopilot(client) | Self::Xai(client) | Self::OpenAi(client) => {
+                send_via_provider(client, request).await
+            }
         }
     }
 
@@ -76,9 +84,11 @@ impl ProviderClient {
             Self::ClawApi(client) => stream_via_provider(client, request)
                 .await
                 .map(MessageStream::ClawApi),
-            Self::Xai(client) | Self::OpenAi(client) => stream_via_provider(client, request)
-                .await
-                .map(MessageStream::OpenAiCompat),
+            Self::GithubCopilot(client) | Self::Xai(client) | Self::OpenAi(client) => {
+                stream_via_provider(client, request)
+                    .await
+                    .map(MessageStream::OpenAiCompat)
+            }
         }
     }
 }

--- a/rust/crates/api/src/client.rs
+++ b/rust/crates/api/src/client.rs
@@ -39,7 +39,7 @@ impl ProviderClient {
         let resolved_model = providers::resolve_model_alias(model);
         match providers::detect_provider_kind(&resolved_model) {
             ProviderKind::ClawApi => Ok(Self::ClawApi(match default_auth {
-                Some(auth) => ClawApiClient::from_auth(auth),
+                Some(auth) => ClawApiClient::from_auth(auth).with_base_url(claw_provider::read_base_url()),
                 None => ClawApiClient::from_env()?,
             })),
             ProviderKind::GithubCopilot => {

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -10,6 +10,13 @@ pub use client::{
 };
 pub use error::ApiError;
 pub use providers::claw_provider::{AuthSource, ClawApiClient, ClawApiClient as ApiClient};
+pub use providers::github_copilot::{
+    clear_github_token as clear_github_copilot_token, load_saved_github_token,
+    poll_for_access_token as poll_for_github_copilot_access_token,
+    request_device_code as request_github_copilot_device_code,
+    resolve_runtime_auth as resolve_github_copilot_runtime_auth,
+    save_github_token as save_github_copilot_token, GithubDeviceCodeResponse,
+};
 pub use providers::openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
 pub use providers::{
     detect_provider_kind, max_tokens_for_model, resolve_model_alias, ProviderKind,

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -16,6 +16,7 @@ pub use providers::github_copilot::{
     poll_for_access_token as poll_for_github_copilot_access_token,
     request_device_code as request_github_copilot_device_code,
     refresh_model_availability as refresh_github_copilot_model_availability,
+    resolve_model_availability as resolve_github_copilot_model_availability,
     resolve_runtime_auth as resolve_github_copilot_runtime_auth,
     save_github_token as save_github_copilot_token, GithubCopilotModelAvailability,
     GithubDeviceCodeResponse,

--- a/rust/crates/api/src/lib.rs
+++ b/rust/crates/api/src/lib.rs
@@ -11,11 +11,14 @@ pub use client::{
 pub use error::ApiError;
 pub use providers::claw_provider::{AuthSource, ClawApiClient, ClawApiClient as ApiClient};
 pub use providers::github_copilot::{
+    cached_model_availability_is_fresh, load_cached_model_availability,
     clear_github_token as clear_github_copilot_token, load_saved_github_token,
     poll_for_access_token as poll_for_github_copilot_access_token,
     request_device_code as request_github_copilot_device_code,
+    refresh_model_availability as refresh_github_copilot_model_availability,
     resolve_runtime_auth as resolve_github_copilot_runtime_auth,
-    save_github_token as save_github_copilot_token, GithubDeviceCodeResponse,
+    save_github_token as save_github_copilot_token, GithubCopilotModelAvailability,
+    GithubDeviceCodeResponse,
 };
 pub use providers::openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
 pub use providers::{

--- a/rust/crates/api/src/providers/github_copilot.rs
+++ b/rust/crates/api/src/providers/github_copilot.rs
@@ -1,0 +1,473 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use runtime::{clear_credentials_entry, load_credentials_entry, save_credentials_entry};
+use serde::{Deserialize, Serialize};
+use crate::error::ApiError;
+use crate::types::MessageRequest;
+
+use super::openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
+
+pub const DEFAULT_BASE_URL: &str = "https://api.individual.githubcopilot.com";
+pub const GITHUB_TOKEN_ENV_VARS: &[&str] = &["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
+
+const DEVICE_CODE_URL: &str = "https://github.com/login/device/code";
+const ACCESS_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+const COPILOT_TOKEN_URL: &str = "https://api.github.com/copilot_internal/v2/token";
+const GITHUB_COPILOT_CLIENT_ID: &str = "Iv1.b507a08c87ecfe98";
+const GITHUB_COPILOT_CREDENTIALS_KEY: &str = "githubCopilot";
+const GITHUB_COPILOT_RUNTIME_KEY: &str = "githubCopilotRuntime";
+const OPENCLAW_RUNTIME_CACHE_RELATIVE_PATH: &str =
+    ".openclaw/credentials/github-copilot.token.json";
+const OPENCLAW_AGENT_DIR_RELATIVE_PATH: &str = ".openclaw/agents";
+const TOKEN_REFRESH_BUFFER_MS: u64 = 5 * 60 * 1000;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GithubCopilotCredentials {
+    pub github_token: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GithubCopilotRuntimeToken {
+    pub token: String,
+    pub expires_at: u64,
+    #[serde(default)]
+    pub updated_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedGithubCopilotAuth {
+    pub api_key: String,
+    pub base_url: String,
+    pub expires_at: u64,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct GithubDeviceCodeResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct GithubDeviceTokenResponse {
+    access_token: Option<String>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct GithubCopilotTokenResponse {
+    token: String,
+    expires_at: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenClawAuthProfiles {
+    profiles: std::collections::BTreeMap<String, OpenClawAuthProfile>,
+}
+
+#[derive(Debug, Deserialize)]
+struct OpenClawAuthProfile {
+    provider: String,
+    #[serde(rename = "type")]
+    kind: String,
+    token: Option<String>,
+}
+
+pub fn create_client(auth: ResolvedGithubCopilotAuth) -> OpenAiCompatClient {
+    OpenAiCompatClient::new(auth.api_key, OpenAiCompatConfig::github_copilot())
+        .with_base_url(auth.base_url)
+}
+
+pub fn client_from_env() -> Result<OpenAiCompatClient, ApiError> {
+    let runtime = tokio::runtime::Runtime::new().map_err(ApiError::from)?;
+    let auth = runtime.block_on(resolve_runtime_auth())?;
+    Ok(create_client(auth))
+}
+
+pub fn save_github_token(github_token: &str) -> Result<(), ApiError> {
+    save_credentials_entry(
+        GITHUB_COPILOT_CREDENTIALS_KEY,
+        &GithubCopilotCredentials {
+            github_token: github_token.to_string(),
+        },
+    )
+    .map_err(ApiError::from)
+}
+
+pub fn clear_github_token() -> Result<(), ApiError> {
+    clear_credentials_entry(GITHUB_COPILOT_CREDENTIALS_KEY).map_err(ApiError::from)
+}
+
+pub fn load_saved_github_token() -> Result<Option<String>, ApiError> {
+    if let Some(github_token) = read_first_non_empty_env(GITHUB_TOKEN_ENV_VARS)? {
+        return Ok(Some(github_token));
+    }
+
+    if let Some(saved) =
+        load_credentials_entry::<GithubCopilotCredentials>(GITHUB_COPILOT_CREDENTIALS_KEY)?
+    {
+        let github_token = saved.github_token.trim();
+        if !github_token.is_empty() {
+            return Ok(Some(github_token.to_string()));
+        }
+    }
+
+    load_openclaw_github_token()
+}
+
+pub fn load_cached_runtime_token() -> Result<Option<ResolvedGithubCopilotAuth>, ApiError> {
+    if let Some(cached) =
+        load_credentials_entry::<GithubCopilotRuntimeToken>(GITHUB_COPILOT_RUNTIME_KEY)?
+    {
+        if is_runtime_token_usable(&cached, now_ms()) {
+            let base_url = derive_base_url_from_token(&cached.token)
+                .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+            return Ok(Some(ResolvedGithubCopilotAuth {
+                api_key: cached.token,
+                base_url,
+                expires_at: cached.expires_at,
+                source: "claw-cache".to_string(),
+            }));
+        }
+    }
+
+    if let Some(cached) = load_openclaw_runtime_token()? {
+        if is_runtime_token_usable(&cached, now_ms()) {
+            let base_url = derive_base_url_from_token(&cached.token)
+                .unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+            return Ok(Some(ResolvedGithubCopilotAuth {
+                api_key: cached.token,
+                base_url,
+                expires_at: cached.expires_at,
+                source: "openclaw-cache".to_string(),
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+pub async fn resolve_runtime_auth() -> Result<ResolvedGithubCopilotAuth, ApiError> {
+    if let Some(cached) = load_cached_runtime_token()? {
+        return Ok(cached);
+    }
+
+    let github_token = load_saved_github_token()?
+        .ok_or_else(|| ApiError::missing_credentials("GitHub Copilot", GITHUB_TOKEN_ENV_VARS))?;
+
+    refresh_runtime_auth(&github_token).await
+}
+
+pub async fn request_device_code() -> Result<GithubDeviceCodeResponse, ApiError> {
+    let response = reqwest::Client::new()
+        .post(DEVICE_CODE_URL)
+        .header("accept", "application/json")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .form(&[
+            ("client_id", GITHUB_COPILOT_CLIENT_ID),
+            ("scope", "read:user"),
+        ])
+        .send()
+        .await
+        .map_err(ApiError::from)?;
+    let response = super::openai_compat::expect_success(response).await?;
+    response
+        .json::<GithubDeviceCodeResponse>()
+        .await
+        .map_err(ApiError::from)
+}
+
+pub async fn poll_for_access_token(device: &GithubDeviceCodeResponse) -> Result<String, ApiError> {
+    let deadline = now_ms().saturating_add(device.expires_in.saturating_mul(1_000));
+    let interval_ms = std::cmp::max(1_000, device.interval.saturating_mul(1_000));
+    let client = reqwest::Client::new();
+
+    while now_ms() < deadline {
+        let response = client
+            .post(ACCESS_TOKEN_URL)
+            .header("accept", "application/json")
+            .header("content-type", "application/x-www-form-urlencoded")
+            .form(&[
+                ("client_id", GITHUB_COPILOT_CLIENT_ID),
+                ("device_code", device.device_code.as_str()),
+                ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+            ])
+            .send()
+            .await
+            .map_err(ApiError::from)?;
+        let response = super::openai_compat::expect_success(response).await?;
+        let payload = response
+            .json::<GithubDeviceTokenResponse>()
+            .await
+            .map_err(ApiError::from)?;
+
+        if let Some(access_token) = payload.access_token {
+            let trimmed = access_token.trim();
+            if !trimmed.is_empty() {
+                return Ok(trimmed.to_string());
+            }
+        }
+
+        match payload.error.as_deref() {
+            Some("authorization_pending") => {
+                tokio::time::sleep(Duration::from_millis(interval_ms)).await;
+            }
+            Some("slow_down") => {
+                tokio::time::sleep(Duration::from_millis(interval_ms + 2_000)).await;
+            }
+            Some("expired_token") => {
+                return Err(ApiError::Auth(
+                    "GitHub device code expired; run login-github-copilot again".to_string(),
+                ));
+            }
+            Some("access_denied") => {
+                return Err(ApiError::Auth("GitHub Copilot login cancelled".to_string()));
+            }
+            Some(other) => {
+                return Err(ApiError::Auth(format!("GitHub device flow error: {other}")));
+            }
+            None => {
+                tokio::time::sleep(Duration::from_millis(interval_ms)).await;
+            }
+        }
+    }
+
+    Err(ApiError::Auth(
+        "GitHub device code expired; run login-github-copilot again".to_string(),
+    ))
+}
+
+pub async fn refresh_runtime_auth(
+    github_token: &str,
+) -> Result<ResolvedGithubCopilotAuth, ApiError> {
+    let response = reqwest::Client::new()
+        .get(COPILOT_TOKEN_URL)
+        .header("accept", "application/json")
+        .header("authorization", format!("Bearer {github_token}"))
+        .header("user-agent", "GitHubCopilotChat/0.35.0")
+        .header("editor-version", "vscode/1.107.0")
+        .header("editor-plugin-version", "copilot-chat/0.35.0")
+        .header("copilot-integration-id", "vscode-chat")
+        .send()
+        .await
+        .map_err(ApiError::from)?;
+    let response = super::openai_compat::expect_success(response).await?;
+    let payload = response
+        .json::<GithubCopilotTokenResponse>()
+        .await
+        .map_err(ApiError::from)?;
+
+    let expires_at = normalize_expires_at(payload.expires_at)?;
+    let base_url =
+        derive_base_url_from_token(&payload.token).unwrap_or_else(|| DEFAULT_BASE_URL.to_string());
+    let cached = GithubCopilotRuntimeToken {
+        token: payload.token.clone(),
+        expires_at,
+        updated_at: Some(now_ms()),
+    };
+    save_credentials_entry(GITHUB_COPILOT_RUNTIME_KEY, &cached).map_err(ApiError::from)?;
+
+    Ok(ResolvedGithubCopilotAuth {
+        api_key: payload.token,
+        base_url,
+        expires_at,
+        source: "github".to_string(),
+    })
+}
+
+pub fn derive_base_url_from_token(token: &str) -> Option<String> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let proxy = trimmed
+        .split(';')
+        .find_map(|segment| segment.trim().strip_prefix("proxy-ep="))?;
+    let host = proxy
+        .trim()
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .replace("proxy.", "api.");
+    (!host.is_empty()).then(|| format!("https://{host}"))
+}
+
+pub fn dynamic_headers_for_request(request: &MessageRequest) -> Vec<(&'static str, String)> {
+    let initiator = request.messages.last().map_or("user", |message| {
+        if message.role == "user" {
+            "user"
+        } else {
+            "agent"
+        }
+    });
+    vec![
+        ("X-Initiator", initiator.to_string()),
+        ("Openai-Intent", "conversation-edits".to_string()),
+    ]
+}
+
+fn load_openclaw_runtime_token() -> Result<Option<GithubCopilotRuntimeToken>, ApiError> {
+    let Some(home) = home_dir() else {
+        return Ok(None);
+    };
+    let path = home.join(OPENCLAW_RUNTIME_CACHE_RELATIVE_PATH);
+    read_json_file::<GithubCopilotRuntimeToken>(&path).map_err(ApiError::from)
+}
+
+fn load_openclaw_github_token() -> Result<Option<String>, ApiError> {
+    let Some(home) = home_dir() else {
+        return Ok(None);
+    };
+    let agents_dir = home.join(OPENCLAW_AGENT_DIR_RELATIVE_PATH);
+    let entries = match fs::read_dir(&agents_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(ApiError::from(error)),
+    };
+
+    for entry in entries {
+        let entry = entry.map_err(ApiError::from)?;
+        let path = entry.path().join("agent").join("auth-profiles.json");
+        let Some(root) = read_json_file::<OpenClawAuthProfiles>(&path).map_err(ApiError::from)?
+        else {
+            continue;
+        };
+        for profile in root.profiles.into_values() {
+            if profile.provider == "github-copilot" && profile.kind == "token" {
+                if let Some(token) = profile.token {
+                    let trimmed = token.trim();
+                    if !trimmed.is_empty() {
+                        return Ok(Some(trimmed.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(None)
+}
+
+fn read_json_file<T>(path: &Path) -> std::io::Result<Option<T>>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    match fs::read_to_string(path) {
+        Ok(contents) => serde_json::from_str(&contents)
+            .map(Some)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
+}
+
+fn read_first_non_empty_env(keys: &[&str]) -> Result<Option<String>, ApiError> {
+    for key in keys {
+        match std::env::var(key) {
+            Ok(value) if !value.trim().is_empty() => return Ok(Some(value)),
+            Ok(_) | Err(std::env::VarError::NotPresent) => {}
+            Err(error) => return Err(ApiError::from(error)),
+        }
+    }
+    Ok(None)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME").map(PathBuf::from)
+}
+
+fn is_runtime_token_usable(cached: &GithubCopilotRuntimeToken, now: u64) -> bool {
+    cached.expires_at.saturating_sub(now) > TOKEN_REFRESH_BUFFER_MS
+}
+
+fn normalize_expires_at(value: u64) -> Result<u64, ApiError> {
+    if value == 0 {
+        return Err(ApiError::Auth(
+            "GitHub Copilot token response missing expires_at".to_string(),
+        ));
+    }
+    Ok(if value < 100_000_000_000 {
+        value.saturating_mul(1_000)
+    } else {
+        value
+    })
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        derive_base_url_from_token, dynamic_headers_for_request, is_runtime_token_usable,
+        normalize_expires_at, GithubCopilotRuntimeToken,
+    };
+    use crate::types::{InputMessage, MessageRequest};
+
+    #[test]
+    fn derives_base_url_from_proxy_endpoint() {
+        let token = "tid=1;exp=9999999999;proxy-ep=proxy.individual.githubcopilot.com;foo=bar";
+        assert_eq!(
+            derive_base_url_from_token(token).as_deref(),
+            Some("https://api.individual.githubcopilot.com")
+        );
+    }
+
+    #[test]
+    fn normalizes_expires_at_seconds_and_millis() {
+        assert_eq!(
+            normalize_expires_at(1_775_176_140).expect("seconds should normalize"),
+            1_775_176_140_000
+        );
+        assert_eq!(
+            normalize_expires_at(1_775_176_140_000).expect("millis should stay millis"),
+            1_775_176_140_000
+        );
+    }
+
+    #[test]
+    fn runtime_token_usability_requires_buffer() {
+        let cached = GithubCopilotRuntimeToken {
+            token: "abc".to_string(),
+            expires_at: 1_000_000,
+            updated_at: Some(1),
+        };
+        assert!(is_runtime_token_usable(&cached, 600_000));
+        assert!(!is_runtime_token_usable(&cached, 800_000));
+    }
+
+    #[test]
+    fn dynamic_headers_switch_to_agent_after_assistant_turn() {
+        let request = MessageRequest {
+            model: "github-copilot/gpt-4o".to_string(),
+            max_tokens: 128,
+            messages: vec![
+                InputMessage::user_text("hi"),
+                InputMessage {
+                    role: "assistant".to_string(),
+                    content: vec![],
+                },
+            ],
+            system: None,
+            tools: None,
+            tool_choice: None,
+            stream: false,
+        };
+
+        let headers = dynamic_headers_for_request(&request);
+        assert!(headers
+            .iter()
+            .any(|(key, value)| *key == "X-Initiator" && value == "agent"));
+        assert!(headers
+            .iter()
+            .any(|(key, value)| *key == "Openai-Intent" && value == "conversation-edits"));
+    }
+}

--- a/rust/crates/api/src/providers/github_copilot.rs
+++ b/rust/crates/api/src/providers/github_copilot.rs
@@ -2,10 +2,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use runtime::{clear_credentials_entry, load_credentials_entry, save_credentials_entry};
-use serde::{Deserialize, Serialize};
 use crate::error::ApiError;
 use crate::types::MessageRequest;
+use runtime::{clear_credentials_entry, load_credentials_entry, save_credentials_entry};
+use serde::{Deserialize, Serialize};
 
 use super::openai_compat::{OpenAiCompatClient, OpenAiCompatConfig};
 

--- a/rust/crates/api/src/providers/github_copilot.rs
+++ b/rust/crates/api/src/providers/github_copilot.rs
@@ -22,6 +22,20 @@ const OPENCLAW_RUNTIME_CACHE_RELATIVE_PATH: &str =
     ".openclaw/credentials/github-copilot.token.json";
 const OPENCLAW_AGENT_DIR_RELATIVE_PATH: &str = ".openclaw/agents";
 const TOKEN_REFRESH_BUFFER_MS: u64 = 5 * 60 * 1000;
+const MODEL_AVAILABILITY_CACHE_KEY: &str = "githubCopilotModelAvailability";
+const MODEL_AVAILABILITY_TTL_MS: u64 = 6 * 60 * 60 * 1000;
+const DEFAULT_MODEL_PROBE_IDS: &[&str] = &[
+    "claude-sonnet-4.6",
+    "claude-sonnet-4.5",
+    "gpt-4o",
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4.1-nano",
+    "o1",
+    "o1-mini",
+    "o3-mini",
+    "gpt-5.4",
+];
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct GithubCopilotCredentials {
@@ -43,6 +57,15 @@ pub struct ResolvedGithubCopilotAuth {
     pub base_url: String,
     pub expires_at: u64,
     pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GithubCopilotModelAvailability {
+    pub checked_at: u64,
+    #[serde(default)]
+    pub available: Vec<String>,
+    #[serde(default)]
+    pub unavailable: Vec<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -102,6 +125,50 @@ pub fn save_github_token(github_token: &str) -> Result<(), ApiError> {
 
 pub fn clear_github_token() -> Result<(), ApiError> {
     clear_credentials_entry(GITHUB_COPILOT_CREDENTIALS_KEY).map_err(ApiError::from)
+}
+
+pub fn load_cached_model_availability() -> Result<Option<GithubCopilotModelAvailability>, ApiError> {
+    load_credentials_entry::<GithubCopilotModelAvailability>(MODEL_AVAILABILITY_CACHE_KEY)
+        .map_err(ApiError::from)
+}
+
+pub fn cached_model_availability_is_fresh(cache: &GithubCopilotModelAvailability) -> bool {
+    now_ms().saturating_sub(cache.checked_at) <= MODEL_AVAILABILITY_TTL_MS
+}
+
+pub async fn refresh_model_availability() -> Result<GithubCopilotModelAvailability, ApiError> {
+    let auth = resolve_runtime_auth().await?;
+    let client = create_client(auth);
+    let mut available = Vec::new();
+    let mut unavailable = Vec::new();
+
+    for model_id in DEFAULT_MODEL_PROBE_IDS {
+        let request = MessageRequest {
+            model: format!("github-copilot/{model_id}"),
+            max_tokens: 8,
+            messages: vec![crate::types::InputMessage::user_text("reply with exactly: ok")],
+            system: None,
+            tools: None,
+            tool_choice: None,
+            stream: false,
+        };
+
+        match client.send_message(&request).await {
+            Ok(_) => available.push((*model_id).to_string()),
+            Err(ApiError::Api { status, .. }) if status == reqwest::StatusCode::BAD_REQUEST => {
+                unavailable.push((*model_id).to_string());
+            }
+            Err(error) => return Err(error),
+        }
+    }
+
+    let cache = GithubCopilotModelAvailability {
+        checked_at: now_ms(),
+        available,
+        unavailable,
+    };
+    save_credentials_entry(MODEL_AVAILABILITY_CACHE_KEY, &cache).map_err(ApiError::from)?;
+    Ok(cache)
 }
 
 pub fn load_saved_github_token() -> Result<Option<String>, ApiError> {

--- a/rust/crates/api/src/providers/github_copilot.rs
+++ b/rust/crates/api/src/providers/github_copilot.rs
@@ -383,7 +383,7 @@ fn load_openclaw_runtime_token() -> Result<Option<GithubCopilotRuntimeToken>, Ap
         return Ok(None);
     };
     let path = home.join(OPENCLAW_RUNTIME_CACHE_RELATIVE_PATH);
-    read_json_file::<GithubCopilotRuntimeToken>(&path).map_err(ApiError::from)
+    read_optional_fallback_json_file::<GithubCopilotRuntimeToken>(&path)
 }
 
 fn load_openclaw_github_token() -> Result<Option<String>, ApiError> {
@@ -400,8 +400,7 @@ fn load_openclaw_github_token() -> Result<Option<String>, ApiError> {
     for entry in entries {
         let entry = entry.map_err(ApiError::from)?;
         let path = entry.path().join("agent").join("auth-profiles.json");
-        let Some(root) = read_json_file::<OpenClawAuthProfiles>(&path).map_err(ApiError::from)?
-        else {
+        let Some(root) = read_optional_fallback_json_file::<OpenClawAuthProfiles>(&path)? else {
             continue;
         };
         for profile in root.profiles.into_values() {
@@ -432,11 +431,27 @@ where
     }
 }
 
+fn read_optional_fallback_json_file<T>(path: &Path) -> Result<Option<T>, ApiError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    match read_json_file(path) {
+        Ok(value) => Ok(value),
+        Err(error) if error.kind() == std::io::ErrorKind::InvalidData => Ok(None),
+        Err(error) => Err(ApiError::from(error)),
+    }
+}
+
 fn read_first_non_empty_env(keys: &[&str]) -> Result<Option<String>, ApiError> {
     for key in keys {
         match std::env::var(key) {
-            Ok(value) if !value.trim().is_empty() => return Ok(Some(value)),
-            Ok(_) | Err(std::env::VarError::NotPresent) => {}
+            Ok(value) => {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    return Ok(Some(trimmed.to_string()));
+                }
+            }
+            Err(std::env::VarError::NotPresent) => {}
             Err(error) => return Err(ApiError::from(error)),
         }
     }

--- a/rust/crates/api/src/providers/github_copilot.rs
+++ b/rust/crates/api/src/providers/github_copilot.rs
@@ -136,6 +136,15 @@ pub fn cached_model_availability_is_fresh(cache: &GithubCopilotModelAvailability
     now_ms().saturating_sub(cache.checked_at) <= MODEL_AVAILABILITY_TTL_MS
 }
 
+pub async fn resolve_model_availability() -> Result<GithubCopilotModelAvailability, ApiError> {
+    if let Some(cache) = load_cached_model_availability()? {
+        if cached_model_availability_is_fresh(&cache) {
+            return Ok(cache);
+        }
+    }
+    refresh_model_availability().await
+}
+
 pub async fn refresh_model_availability() -> Result<GithubCopilotModelAvailability, ApiError> {
     let auth = resolve_runtime_auth().await?;
     let client = create_client(auth);

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -5,6 +5,7 @@ use crate::error::ApiError;
 use crate::types::{MessageRequest, MessageResponse};
 
 pub mod claw_provider;
+pub mod github_copilot;
 pub mod openai_compat;
 
 pub type ProviderFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, ApiError>> + Send + 'a>>;
@@ -26,6 +27,7 @@ pub trait Provider {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ProviderKind {
     ClawApi,
+    GithubCopilot,
     Xai,
     OpenAi,
 }
@@ -91,6 +93,24 @@ const MODEL_REGISTRY: &[(&str, ProviderMetadata)] = &[
             auth_env: "ANTHROPIC_API_KEY",
             base_url_env: "ANTHROPIC_BASE_URL",
             default_base_url: claw_provider::DEFAULT_BASE_URL,
+        },
+    ),
+    (
+        "github-copilot/gpt-4o",
+        ProviderMetadata {
+            provider: ProviderKind::GithubCopilot,
+            auth_env: "COPILOT_GITHUB_TOKEN",
+            base_url_env: "COPILOT_BASE_URL",
+            default_base_url: github_copilot::DEFAULT_BASE_URL,
+        },
+    ),
+    (
+        "github-copilot/gpt-5.4",
+        ProviderMetadata {
+            provider: ProviderKind::GithubCopilot,
+            auth_env: "COPILOT_GITHUB_TOKEN",
+            base_url_env: "COPILOT_BASE_URL",
+            default_base_url: github_copilot::DEFAULT_BASE_URL,
         },
     ),
     (
@@ -160,6 +180,7 @@ pub fn resolve_model_alias(model: &str) -> String {
                     "grok-2" => "grok-2",
                     _ => trimmed,
                 },
+                ProviderKind::GithubCopilot => trimmed,
                 ProviderKind::OpenAi => trimmed,
             })
         })
@@ -172,6 +193,14 @@ pub fn metadata_for_model(model: &str) -> Option<ProviderMetadata> {
     let lower = canonical.to_ascii_lowercase();
     if let Some((_, metadata)) = MODEL_REGISTRY.iter().find(|(alias, _)| *alias == lower) {
         return Some(*metadata);
+    }
+    if lower.starts_with("github-copilot/") {
+        return Some(ProviderMetadata {
+            provider: ProviderKind::GithubCopilot,
+            auth_env: "COPILOT_GITHUB_TOKEN",
+            base_url_env: "COPILOT_BASE_URL",
+            default_base_url: github_copilot::DEFAULT_BASE_URL,
+        });
     }
     if lower.starts_with("grok") {
         return Some(ProviderMetadata {
@@ -192,6 +221,17 @@ pub fn detect_provider_kind(model: &str) -> ProviderKind {
     if claw_provider::has_auth_from_env_or_saved().unwrap_or(false) {
         return ProviderKind::ClawApi;
     }
+    if github_copilot::load_saved_github_token()
+        .ok()
+        .and_then(std::convert::identity)
+        .is_some()
+        || github_copilot::load_cached_runtime_token()
+            .ok()
+            .and_then(std::convert::identity)
+            .is_some()
+    {
+        return ProviderKind::GithubCopilot;
+    }
     if openai_compat::has_api_key("OPENAI_API_KEY") {
         return ProviderKind::OpenAi;
     }
@@ -204,7 +244,9 @@ pub fn detect_provider_kind(model: &str) -> ProviderKind {
 #[must_use]
 pub fn max_tokens_for_model(model: &str) -> u32 {
     let canonical = resolve_model_alias(model);
-    if canonical.contains("opus") {
+    if canonical.starts_with("github-copilot/") {
+        8_192
+    } else if canonical.contains("opus") {
         32_000
     } else {
         64_000
@@ -226,6 +268,10 @@ mod tests {
     fn detects_provider_from_model_name_first() {
         assert_eq!(detect_provider_kind("grok"), ProviderKind::Xai);
         assert_eq!(
+            detect_provider_kind("github-copilot/gpt-4o"),
+            ProviderKind::GithubCopilot
+        );
+        assert_eq!(
             detect_provider_kind("claude-sonnet-4-6"),
             ProviderKind::ClawApi
         );
@@ -235,5 +281,6 @@ mod tests {
     fn keeps_existing_max_token_heuristic() {
         assert_eq!(max_tokens_for_model("opus"), 32_000);
         assert_eq!(max_tokens_for_model("grok-3"), 64_000);
+        assert_eq!(max_tokens_for_model("github-copilot/gpt-4o"), 8_192);
     }
 }

--- a/rust/crates/api/src/providers/mod.rs
+++ b/rust/crates/api/src/providers/mod.rs
@@ -221,6 +221,12 @@ pub fn detect_provider_kind(model: &str) -> ProviderKind {
     if claw_provider::has_auth_from_env_or_saved().unwrap_or(false) {
         return ProviderKind::ClawApi;
     }
+    if openai_compat::has_api_key("OPENAI_API_KEY") {
+        return ProviderKind::OpenAi;
+    }
+    if openai_compat::has_api_key("XAI_API_KEY") {
+        return ProviderKind::Xai;
+    }
     if github_copilot::load_saved_github_token()
         .ok()
         .and_then(std::convert::identity)
@@ -231,12 +237,6 @@ pub fn detect_provider_kind(model: &str) -> ProviderKind {
             .is_some()
     {
         return ProviderKind::GithubCopilot;
-    }
-    if openai_compat::has_api_key("OPENAI_API_KEY") {
-        return ProviderKind::OpenAi;
-    }
-    if openai_compat::has_api_key("XAI_API_KEY") {
-        return ProviderKind::Xai;
     }
     ProviderKind::ClawApi
 }

--- a/rust/crates/api/src/providers/openai_compat.rs
+++ b/rust/crates/api/src/providers/openai_compat.rs
@@ -12,10 +12,12 @@ use crate::types::{
     ToolChoice, ToolDefinition, ToolResultContentBlock, Usage,
 };
 
+use super::github_copilot;
 use super::{Provider, ProviderFuture};
 
 pub const DEFAULT_XAI_BASE_URL: &str = "https://api.x.ai/v1";
 pub const DEFAULT_OPENAI_BASE_URL: &str = "https://api.openai.com/v1";
+pub const DEFAULT_GITHUB_COPILOT_BASE_URL: &str = github_copilot::DEFAULT_BASE_URL;
 const REQUEST_ID_HEADER: &str = "request-id";
 const ALT_REQUEST_ID_HEADER: &str = "x-request-id";
 const DEFAULT_INITIAL_BACKOFF: Duration = Duration::from_millis(200);
@@ -32,6 +34,7 @@ pub struct OpenAiCompatConfig {
 
 const XAI_ENV_VARS: &[&str] = &["XAI_API_KEY"];
 const OPENAI_ENV_VARS: &[&str] = &["OPENAI_API_KEY"];
+const GITHUB_COPILOT_ENV_VARS: &[&str] = &["COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"];
 
 impl OpenAiCompatConfig {
     #[must_use]
@@ -53,11 +56,23 @@ impl OpenAiCompatConfig {
             default_base_url: DEFAULT_OPENAI_BASE_URL,
         }
     }
+
+    #[must_use]
+    pub const fn github_copilot() -> Self {
+        Self {
+            provider_name: "GitHub Copilot",
+            api_key_env: "COPILOT_GITHUB_TOKEN",
+            base_url_env: "COPILOT_BASE_URL",
+            default_base_url: DEFAULT_GITHUB_COPILOT_BASE_URL,
+        }
+    }
+
     #[must_use]
     pub fn credential_env_vars(self) -> &'static [&'static str] {
         match self.provider_name {
             "xAI" => XAI_ENV_VARS,
             "OpenAI" => OPENAI_ENV_VARS,
+            "GitHub Copilot" => GITHUB_COPILOT_ENV_VARS,
             _ => &[],
         }
     }
@@ -66,6 +81,7 @@ impl OpenAiCompatConfig {
 #[derive(Debug, Clone)]
 pub struct OpenAiCompatClient {
     http: reqwest::Client,
+    config: OpenAiCompatConfig,
     api_key: String,
     base_url: String,
     max_retries: u32,
@@ -78,6 +94,7 @@ impl OpenAiCompatClient {
     pub fn new(api_key: impl Into<String>, config: OpenAiCompatConfig) -> Self {
         Self {
             http: reqwest::Client::new(),
+            config,
             api_key: api_key.into(),
             base_url: read_base_url(config),
             max_retries: DEFAULT_MAX_RETRIES,
@@ -186,10 +203,20 @@ impl OpenAiCompatClient {
         request: &MessageRequest,
     ) -> Result<reqwest::Response, ApiError> {
         let request_url = chat_completions_endpoint(&self.base_url);
-        self.http
+        let mut request_builder = self
+            .http
             .post(&request_url)
             .header("content-type", "application/json")
-            .bearer_auth(&self.api_key)
+            .bearer_auth(&self.api_key);
+
+        for (key, value) in static_headers_for_config(self.config) {
+            request_builder = request_builder.header(*key, *value);
+        }
+        for (key, value) in dynamic_headers_for_config(self.config, request) {
+            request_builder = request_builder.header(key, value);
+        }
+
+        request_builder
             .json(&build_chat_completion_request(request))
             .send()
             .await
@@ -643,12 +670,18 @@ fn build_chat_completion_request(request: &MessageRequest) -> Value {
         messages.extend(translate_message(message));
     }
 
+    let model_name = effective_model_name(request);
     let mut payload = json!({
-        "model": request.model,
-        "max_tokens": request.max_tokens,
+        "model": model_name,
         "messages": messages,
         "stream": request.stream,
     });
+
+    if uses_max_completion_tokens(&model_name) {
+        payload["max_completion_tokens"] = json!(request.max_tokens);
+    } else {
+        payload["max_tokens"] = json!(request.max_tokens);
+    }
 
     if let Some(tools) = &request.tools {
         payload["tools"] =
@@ -659,6 +692,18 @@ fn build_chat_completion_request(request: &MessageRequest) -> Value {
     }
 
     payload
+}
+
+fn effective_model_name(request: &MessageRequest) -> String {
+    request
+        .model
+        .strip_prefix("github-copilot/")
+        .unwrap_or(&request.model)
+        .to_string()
+}
+
+fn uses_max_completion_tokens(model_name: &str) -> bool {
+    model_name.trim().to_ascii_lowercase().starts_with("gpt-5")
 }
 
 fn translate_message(message: &InputMessage) -> Vec<Value> {
@@ -883,7 +928,9 @@ fn request_id_from_headers(headers: &reqwest::header::HeaderMap) -> Option<Strin
         .map(ToOwned::to_owned)
 }
 
-async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response, ApiError> {
+pub(crate) async fn expect_success(
+    response: reqwest::Response,
+) -> Result<reqwest::Response, ApiError> {
     let status = response.status();
     if status.is_success() {
         return Ok(response);
@@ -904,6 +951,30 @@ async fn expect_success(response: reqwest::Response) -> Result<reqwest::Response
         body,
         retryable,
     })
+}
+
+fn static_headers_for_config(
+    config: OpenAiCompatConfig,
+) -> &'static [(&'static str, &'static str)] {
+    match config.provider_name {
+        "GitHub Copilot" => &[
+            ("User-Agent", "GitHubCopilotChat/0.35.0"),
+            ("Editor-Version", "vscode/1.107.0"),
+            ("Editor-Plugin-Version", "copilot-chat/0.35.0"),
+            ("Copilot-Integration-Id", "vscode-chat"),
+        ],
+        _ => &[],
+    }
+}
+
+fn dynamic_headers_for_config(
+    config: OpenAiCompatConfig,
+    request: &MessageRequest,
+) -> Vec<(&'static str, String)> {
+    match config.provider_name {
+        "GitHub Copilot" => github_copilot::dynamic_headers_for_request(request),
+        _ => Vec::new(),
+    }
 }
 
 const fn is_retryable_status(status: reqwest::StatusCode) -> bool {
@@ -982,6 +1053,23 @@ mod tests {
         assert_eq!(payload["messages"][2]["role"], json!("tool"));
         assert_eq!(payload["tools"][0]["type"], json!("function"));
         assert_eq!(payload["tool_choice"], json!("auto"));
+    }
+
+    #[test]
+    fn github_copilot_request_translation_normalizes_model_and_token_field() {
+        let payload = build_chat_completion_request(&MessageRequest {
+            model: "github-copilot/gpt-5.4".to_string(),
+            max_tokens: 128,
+            messages: vec![InputMessage::user_text("hello")],
+            system: None,
+            tools: None,
+            tool_choice: None,
+            stream: false,
+        });
+
+        assert_eq!(payload["model"], json!("gpt-5.4"));
+        assert_eq!(payload["max_completion_tokens"], json!(128));
+        assert!(payload.get("max_tokens").is_none());
     }
 
     #[test]

--- a/rust/crates/claw-cli/Cargo.toml
+++ b/rust/crates/claw-cli/Cargo.toml
@@ -18,6 +18,7 @@ pulldown-cmark = "0.13"
 rustyline = "15"
 runtime = { path = "../runtime" }
 plugins = { path = "../plugins" }
+serde.workspace = true
 serde_json.workspace = true
 syntect = "5"
 tokio = { version = "1", features = ["rt-multi-thread", "time"] }

--- a/rust/crates/claw-cli/src/main.rs
+++ b/rust/crates/claw-cli/src/main.rs
@@ -16,9 +16,9 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use api::{
-    cached_model_availability_is_fresh, load_cached_model_availability, load_saved_github_token,
-    poll_for_github_copilot_access_token, refresh_github_copilot_model_availability,
-    request_github_copilot_device_code, resolve_startup_auth_source,
+    load_saved_github_token, poll_for_github_copilot_access_token,
+    request_github_copilot_device_code, resolve_github_copilot_model_availability,
+    resolve_startup_auth_source,
     save_github_copilot_token, AuthSource, ClawApiClient, ContentBlockDelta,
     GithubCopilotModelAvailability, InputContentBlock, InputMessage, MessageRequest,
     MessageResponse, OutputContentBlock, ProviderClient, StreamEvent as ApiStreamEvent,
@@ -40,8 +40,8 @@ use runtime::{
     save_oauth_credentials, ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader,
     ConfigSource, ContentBlock, ConversationMessage, ConversationRuntime, MessageRole,
     OAuthAuthorizationRequest, OAuthConfig, OAuthTokenExchangeRequest, PermissionMode,
-    PermissionPolicy, ProjectContext, RuntimeError, Session, TokenUsage, ToolError, ToolExecutor,
-    UsageTracker,
+    PermissionPolicy, ProjectContext, RuntimeError, Session, StartupPreferences, TokenUsage,
+    ToolError, ToolExecutor, UsageTracker,
 };
 use serde_json::json;
 use tools::GlobalToolRegistry;
@@ -59,12 +59,6 @@ const GIT_SHA: Option<&str> = option_env!("GIT_SHA");
 const INTERNAL_PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3);
 
 type AllowedToolSet = BTreeSet<String>;
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-struct StartupPreferences {
-    #[serde(default)]
-    default_model: Option<String>,
-}
 
 fn main() {
     if let Err(error) = run() {
@@ -183,6 +177,13 @@ impl CliOutputFormat {
 
 #[allow(clippy::too_many_lines)]
 fn parse_args(args: &[String]) -> Result<CliAction, String> {
+    if args.iter().any(|arg| matches!(arg.as_str(), "--version" | "-V")) {
+        return Ok(CliAction::Version);
+    }
+    if matches!(args.first().map(String::as_str), Some("--help" | "-h")) {
+        return Ok(CliAction::Help);
+    }
+
     let mut model = resolve_startup_default_model();
     let mut output_format = CliOutputFormat::Text;
     let mut permission_mode = default_permission_mode();
@@ -443,14 +444,8 @@ fn copilot_model_availability_for_report(model: &str) -> Option<GithubCopilotMod
     if !model.starts_with("github-copilot/") {
         return None;
     }
-    match load_cached_model_availability() {
-        Ok(Some(cache)) if cached_model_availability_is_fresh(&cache) => Some(cache),
-        Ok(_) => {
-            let runtime = tokio::runtime::Runtime::new().ok()?;
-            runtime.block_on(refresh_github_copilot_model_availability()).ok()
-        }
-        Err(_) => None,
-    }
+    let runtime = tokio::runtime::Runtime::new().ok()?;
+    runtime.block_on(resolve_github_copilot_model_availability()).ok()
 }
 
 fn now_ms() -> u64 {
@@ -653,7 +648,7 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
         remember_startup_default_model(DEFAULT_GITHUB_COPILOT_MODEL)?;
         let runtime = tokio::runtime::Runtime::new()?;
         let resolved = runtime.block_on(api::resolve_github_copilot_runtime_auth())?;
-        let availability = runtime.block_on(refresh_github_copilot_model_availability()).ok();
+        let availability = runtime.block_on(resolve_github_copilot_model_availability()).ok();
         let expires_in_minutes = resolved.expires_at.saturating_sub(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -690,7 +685,7 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
     save_github_copilot_token(&github_token)?;
     remember_startup_default_model(DEFAULT_GITHUB_COPILOT_MODEL)?;
     let resolved = runtime.block_on(api::resolve_github_copilot_runtime_auth())?;
-    let availability = runtime.block_on(refresh_github_copilot_model_availability()).ok();
+    let availability = runtime.block_on(resolve_github_copilot_model_availability()).ok();
     let expires_in_minutes = resolved.expires_at.saturating_sub(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -4393,6 +4388,22 @@ mod tests {
         }
     }
 
+    struct ScopedTempDir {
+        path: std::path::PathBuf,
+    }
+
+    impl ScopedTempDir {
+        fn new(path: std::path::PathBuf) -> Self {
+            Self { path }
+        }
+    }
+
+    impl Drop for ScopedTempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
     fn with_clean_config_home<T>(f: impl FnOnce() -> T) -> T {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         let _lock = LOCK
@@ -4408,10 +4419,9 @@ mod tests {
                 .as_nanos()
         ));
         fs::create_dir_all(&config_home).expect("temp config home should be created");
+        let _dir_guard = ScopedTempDir::new(config_home.clone());
         let _env_guard = ScopedEnvVar::set("CLAW_CONFIG_HOME", &config_home);
-        let result = f();
-        let _ = fs::remove_dir_all(config_home);
-        result
+        f()
     }
 
     fn parse_args_isolated(args: &[String]) -> Result<CliAction, String> {

--- a/rust/crates/claw-cli/src/main.rs
+++ b/rust/crates/claw-cli/src/main.rs
@@ -4370,6 +4370,29 @@ mod tests {
         .expect("plugin tool registry should build")
     }
 
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &std::path::Path) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
     fn with_clean_config_home<T>(f: impl FnOnce() -> T) -> T {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
         let _lock = LOCK
@@ -4384,15 +4407,9 @@ mod tests {
                 .expect("clock should move forward")
                 .as_nanos()
         ));
-        let previous = std::env::var_os("CLAW_CONFIG_HOME");
         fs::create_dir_all(&config_home).expect("temp config home should be created");
-        std::env::set_var("CLAW_CONFIG_HOME", &config_home);
+        let _env_guard = ScopedEnvVar::set("CLAW_CONFIG_HOME", &config_home);
         let result = f();
-        if let Some(previous) = previous {
-            std::env::set_var("CLAW_CONFIG_HOME", previous);
-        } else {
-            std::env::remove_var("CLAW_CONFIG_HOME");
-        }
         let _ = fs::remove_dir_all(config_home);
         result
     }

--- a/rust/crates/claw-cli/src/main.rs
+++ b/rust/crates/claw-cli/src/main.rs
@@ -16,9 +16,11 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use api::{
-    resolve_startup_auth_source, AuthSource, ClawApiClient, ContentBlockDelta, InputContentBlock,
-    InputMessage, MessageRequest, MessageResponse, OutputContentBlock,
-    StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
+    poll_for_github_copilot_access_token, request_github_copilot_device_code,
+    save_github_copilot_token, AuthSource, ClawApiClient, ContentBlockDelta,
+    InputContentBlock, InputMessage, MessageRequest, MessageResponse, OutputContentBlock,
+    ProviderClient, StreamEvent as ApiStreamEvent, ToolChoice,
+    ToolDefinition, ToolResultContentBlock,
 };
 
 use commands::{
@@ -101,7 +103,9 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
         } => LiveCli::new(model, true, allowed_tools, permission_mode)?
             .run_turn_with_output(&prompt, output_format)?,
         CliAction::Login => run_login()?,
+        CliAction::LoginGithubCopilot => run_login_github_copilot()?,
         CliAction::Logout => run_logout()?,
+        CliAction::LogoutGithubCopilot => run_logout_github_copilot()?,
         CliAction::Init => run_init()?,
         CliAction::Repl {
             model,
@@ -140,7 +144,9 @@ enum CliAction {
         permission_mode: PermissionMode,
     },
     Login,
+    LoginGithubCopilot,
     Logout,
+    LogoutGithubCopilot,
     Init,
     Repl {
         model: String,
@@ -294,7 +300,9 @@ fn parse_args(args: &[String]) -> Result<CliAction, String> {
         }),
         "system-prompt" => parse_system_prompt_args(&rest[1..]),
         "login" => Ok(CliAction::Login),
+        "login-github-copilot" => Ok(CliAction::LoginGithubCopilot),
         "logout" => Ok(CliAction::Logout),
+        "logout-github-copilot" => Ok(CliAction::LogoutGithubCopilot),
         "init" => Ok(CliAction::Init),
         "prompt" => {
             let prompt = rest[1..].join(" ");
@@ -555,9 +563,48 @@ fn run_login() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
+    if !io::stdin().is_terminal() {
+        return Err(io::Error::other("GitHub Copilot login requires an interactive TTY").into());
+    }
+
+    println!("Starting GitHub Copilot device login...");
+    let runtime = tokio::runtime::Runtime::new()?;
+    let device = runtime.block_on(request_github_copilot_device_code())?;
+
+    println!("Open this URL and enter the code below:");
+    println!("{}", device.verification_uri);
+    println!("Code: {}", device.user_code);
+    if let Err(error) = open_browser(&device.verification_uri) {
+        eprintln!("warning: failed to open browser automatically: {error}");
+    }
+
+    let github_token = runtime.block_on(poll_for_github_copilot_access_token(&device))?;
+    save_github_copilot_token(&github_token)?;
+    let resolved = runtime.block_on(api::resolve_github_copilot_runtime_auth())?;
+    let expires_in_minutes = resolved.expires_at.saturating_sub(
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64,
+    ) / 60_000;
+
+    println!("GitHub Copilot login complete.");
+    println!("Cached Copilot token source: {}", resolved.source);
+    println!("Cached Copilot token expires in ~{expires_in_minutes} minutes.");
+    Ok(())
+}
+
 fn run_logout() -> Result<(), Box<dyn std::error::Error>> {
     clear_oauth_credentials()?;
     println!("Claw OAuth credentials cleared.");
+    Ok(())
+}
+
+fn run_logout_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
+    api::clear_github_copilot_token()?;
+    runtime::clear_credentials_entry("githubCopilotRuntime")?;
+    println!("GitHub Copilot credentials cleared.");
     Ok(())
 }
 
@@ -3040,7 +3087,7 @@ impl runtime::PermissionPrompter for CliPermissionPrompter {
 
 struct DefaultRuntimeClient {
     runtime: tokio::runtime::Runtime,
-    client: ClawApiClient,
+    client: ProviderClient,
     model: String,
     enable_tools: bool,
     emit_output: bool,
@@ -3060,8 +3107,7 @@ impl DefaultRuntimeClient {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self {
             runtime: tokio::runtime::Runtime::new()?,
-            client: ClawApiClient::from_auth(resolve_cli_auth_source()?)
-                .with_base_url(api::read_base_url()),
+            client: ProviderClient::from_model(&model)?,
             model,
             enable_tools,
             emit_output,
@@ -3070,16 +3116,6 @@ impl DefaultRuntimeClient {
             progress_reporter,
         })
     }
-}
-
-fn resolve_cli_auth_source() -> Result<AuthSource, Box<dyn std::error::Error>> {
-    Ok(resolve_startup_auth_source(|| {
-        let cwd = env::current_dir().map_err(api::ApiError::from)?;
-        let config = ConfigLoader::default_for(&cwd).load().map_err(|error| {
-            api::ApiError::Auth(format!("failed to load runtime OAuth config: {error}"))
-        })?;
-        Ok(config.oauth().cloned())
-    })?)
 }
 
 impl ApiClient for DefaultRuntimeClient {
@@ -4035,7 +4071,15 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     )?;
     writeln!(
         out,
+        "  claw login-github-copilot             Start the GitHub Copilot device login flow"
+    )?;
+    writeln!(
+        out,
         "  claw logout                           Clear saved OAuth credentials"
+    )?;
+    writeln!(
+        out,
+        "  claw logout-github-copilot            Clear saved GitHub Copilot credentials"
     )?;
     writeln!(
         out,
@@ -4097,6 +4141,7 @@ fn print_help_to(out: &mut impl Write) -> io::Result<()> {
     writeln!(out, "  claw agents")?;
     writeln!(out, "  claw /skills")?;
     writeln!(out, "  claw login")?;
+    writeln!(out, "  claw login-github-copilot")?;
     writeln!(out, "  claw init")?;
     Ok(())
 }
@@ -4310,8 +4355,18 @@ mod tests {
             CliAction::Login
         );
         assert_eq!(
+            parse_args(&["login-github-copilot".to_string()])
+                .expect("login-github-copilot should parse"),
+            CliAction::LoginGithubCopilot
+        );
+        assert_eq!(
             parse_args(&["logout".to_string()]).expect("logout should parse"),
             CliAction::Logout
+        );
+        assert_eq!(
+            parse_args(&["logout-github-copilot".to_string()])
+                .expect("logout-github-copilot should parse"),
+            CliAction::LogoutGithubCopilot
         );
         assert_eq!(
             parse_args(&["init".to_string()]).expect("init should parse"),

--- a/rust/crates/claw-cli/src/main.rs
+++ b/rust/crates/claw-cli/src/main.rs
@@ -722,6 +722,7 @@ fn run_logout() -> Result<(), Box<dyn std::error::Error>> {
 fn run_logout_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
     api::clear_github_copilot_token()?;
     runtime::clear_credentials_entry("githubCopilotRuntime")?;
+    runtime::clear_credentials_entry("githubCopilotModelAvailability")?;
     clear_startup_default_model_if_matches("github-copilot/")?;
     println!("GitHub Copilot credentials cleared.");
     Ok(())
@@ -4383,10 +4384,15 @@ mod tests {
                 .expect("clock should move forward")
                 .as_nanos()
         ));
+        let previous = std::env::var_os("CLAW_CONFIG_HOME");
         fs::create_dir_all(&config_home).expect("temp config home should be created");
         std::env::set_var("CLAW_CONFIG_HOME", &config_home);
         let result = f();
-        std::env::remove_var("CLAW_CONFIG_HOME");
+        if let Some(previous) = previous {
+            std::env::set_var("CLAW_CONFIG_HOME", previous);
+        } else {
+            std::env::remove_var("CLAW_CONFIG_HOME");
+        }
         let _ = fs::remove_dir_all(config_home);
         result
     }

--- a/rust/crates/claw-cli/src/main.rs
+++ b/rust/crates/claw-cli/src/main.rs
@@ -16,11 +16,11 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use api::{
-    poll_for_github_copilot_access_token, request_github_copilot_device_code,
-    save_github_copilot_token, AuthSource, ClawApiClient, ContentBlockDelta,
-    InputContentBlock, InputMessage, MessageRequest, MessageResponse, OutputContentBlock,
-    ProviderClient, StreamEvent as ApiStreamEvent, ToolChoice,
-    ToolDefinition, ToolResultContentBlock,
+    load_saved_github_token, poll_for_github_copilot_access_token,
+    request_github_copilot_device_code, save_github_copilot_token, AuthSource, ClawApiClient,
+    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
+    OutputContentBlock, ProviderClient, StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition,
+    ToolResultContentBlock,
 };
 
 use commands::{
@@ -33,17 +33,19 @@ use init::initialize_repo;
 use plugins::{PluginManager, PluginManagerConfig};
 use render::{MarkdownStreamState, Spinner, TerminalRenderer};
 use runtime::{
-    clear_oauth_credentials, generate_pkce_pair, generate_state, load_system_prompt,
-    parse_oauth_callback_request_target, save_oauth_credentials, ApiClient, ApiRequest,
-    AssistantEvent, CompactionConfig, ConfigLoader, ConfigSource, ContentBlock,
-    ConversationMessage, ConversationRuntime, MessageRole, OAuthAuthorizationRequest, OAuthConfig,
-    OAuthTokenExchangeRequest, PermissionMode, PermissionPolicy, ProjectContext, RuntimeError,
-    Session, TokenUsage, ToolError, ToolExecutor, UsageTracker,
+    clear_oauth_credentials, generate_pkce_pair, generate_state, load_credentials_entry,
+    load_system_prompt, parse_oauth_callback_request_target, save_credentials_entry,
+    save_oauth_credentials, ApiClient, ApiRequest, AssistantEvent, CompactionConfig, ConfigLoader,
+    ConfigSource, ContentBlock, ConversationMessage, ConversationRuntime, MessageRole,
+    OAuthAuthorizationRequest, OAuthConfig, OAuthTokenExchangeRequest, PermissionMode,
+    PermissionPolicy, ProjectContext, RuntimeError, Session, TokenUsage, ToolError, ToolExecutor,
+    UsageTracker,
 };
 use serde_json::json;
 use tools::GlobalToolRegistry;
 
 const DEFAULT_MODEL: &str = "claude-opus-4-6";
+const DEFAULT_GITHUB_COPILOT_MODEL: &str = "github-copilot/gpt-5.4";
 fn max_tokens_for_model(model: &str) -> u32 {
     if model.contains("opus") {
         32_000
@@ -59,6 +61,12 @@ const GIT_SHA: Option<&str> = option_env!("GIT_SHA");
 const INTERNAL_PROGRESS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(3);
 
 type AllowedToolSet = BTreeSet<String>;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct StartupPreferences {
+    #[serde(default)]
+    default_model: Option<String>,
+}
 
 fn main() {
     if let Err(error) = run() {
@@ -177,7 +185,7 @@ impl CliOutputFormat {
 
 #[allow(clippy::too_many_lines)]
 fn parse_args(args: &[String]) -> Result<CliAction, String> {
-    let mut model = DEFAULT_MODEL.to_string();
+    let mut model = resolve_startup_default_model();
     let mut output_format = CliOutputFormat::Text;
     let mut permission_mode = default_permission_mode();
     let mut wants_version = false;
@@ -375,8 +383,62 @@ fn resolve_model_alias(model: &str) -> &str {
         "opus" => "claude-opus-4-6",
         "sonnet" => "claude-sonnet-4-6",
         "haiku" => "claude-haiku-4-5-20251213",
+        "copilot" => DEFAULT_GITHUB_COPILOT_MODEL,
+        "copilot-4o" => "github-copilot/gpt-4o",
         _ => model,
     }
+}
+
+fn resolve_startup_default_model() -> String {
+    if let Ok(Some(preferences)) =
+        load_credentials_entry::<StartupPreferences>("startupPreferences")
+    {
+        if let Some(model) = preferences
+            .default_model
+            .as_deref()
+            .map(resolve_model_alias)
+            .filter(|model| !model.trim().is_empty())
+        {
+            return model.to_string();
+        }
+    }
+    DEFAULT_MODEL.to_string()
+}
+
+fn remember_startup_default_model(model: &str) -> Result<(), Box<dyn std::error::Error>> {
+    save_credentials_entry(
+        "startupPreferences",
+        &StartupPreferences {
+            default_model: Some(resolve_model_alias(model).to_string()),
+        },
+    )?;
+    Ok(())
+}
+
+fn clear_startup_default_model_if_matches(prefix: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let Some(mut preferences) = load_credentials_entry::<StartupPreferences>("startupPreferences")?
+    else {
+        return Ok(());
+    };
+    if preferences
+        .default_model
+        .as_deref()
+        .is_some_and(|model| model.starts_with(prefix))
+    {
+        preferences.default_model = None;
+        save_credentials_entry("startupPreferences", &preferences)?;
+    }
+    Ok(())
+}
+
+fn uses_github_copilot_startup_default(model: &str) -> bool {
+    load_credentials_entry::<StartupPreferences>("startupPreferences")
+        .ok()
+        .and_then(std::convert::identity)
+        .and_then(|preferences| preferences.default_model)
+        .is_some_and(|preferred| {
+            resolve_model_alias(&preferred) == model && model.starts_with("github-copilot/")
+        })
 }
 
 fn normalize_allowed_tools(values: &[String]) -> Result<Option<AllowedToolSet>, String> {
@@ -568,6 +630,25 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
         return Err(io::Error::other("GitHub Copilot login requires an interactive TTY").into());
     }
 
+    if load_saved_github_token()?.is_some() {
+        remember_startup_default_model(DEFAULT_GITHUB_COPILOT_MODEL)?;
+        let runtime = tokio::runtime::Runtime::new()?;
+        let resolved = runtime.block_on(api::resolve_github_copilot_runtime_auth())?;
+        let expires_in_minutes = resolved.expires_at.saturating_sub(
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as u64,
+        ) / 60_000;
+        println!("GitHub Copilot credentials already available.");
+        println!("Cached Copilot token source: {}", resolved.source);
+        println!("Cached Copilot token expires in ~{expires_in_minutes} minutes.");
+        println!(
+            "Future `claw` launches will default to {DEFAULT_GITHUB_COPILOT_MODEL}. Use `--model` or `/model` to override."
+        );
+        return Ok(());
+    }
+
     println!("Starting GitHub Copilot device login...");
     let runtime = tokio::runtime::Runtime::new()?;
     let device = runtime.block_on(request_github_copilot_device_code())?;
@@ -581,6 +662,7 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
 
     let github_token = runtime.block_on(poll_for_github_copilot_access_token(&device))?;
     save_github_copilot_token(&github_token)?;
+    remember_startup_default_model(DEFAULT_GITHUB_COPILOT_MODEL)?;
     let resolved = runtime.block_on(api::resolve_github_copilot_runtime_auth())?;
     let expires_in_minutes = resolved.expires_at.saturating_sub(
         SystemTime::now()
@@ -592,6 +674,9 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
     println!("GitHub Copilot login complete.");
     println!("Cached Copilot token source: {}", resolved.source);
     println!("Cached Copilot token expires in ~{expires_in_minutes} minutes.");
+    println!(
+        "Future `claw` launches will default to {DEFAULT_GITHUB_COPILOT_MODEL}. Use `--model` or `/model` to override."
+    );
     Ok(())
 }
 
@@ -604,6 +689,7 @@ fn run_logout() -> Result<(), Box<dyn std::error::Error>> {
 fn run_logout_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
     api::clear_github_copilot_token()?;
     runtime::clear_credentials_entry("githubCopilotRuntime")?;
+    clear_startup_default_model_if_matches("github-copilot/")?;
     println!("GitHub Copilot credentials cleared.");
     Ok(())
 }
@@ -754,6 +840,8 @@ Aliases
   opus             claude-opus-4-6
   sonnet           claude-sonnet-4-6
   haiku            claude-haiku-4-5-20251213
+  copilot          github-copilot/gpt-5.4
+  copilot-4o       github-copilot/gpt-4o
 
 Next
   /model           Show the current model
@@ -1200,6 +1288,12 @@ impl LiveCli {
         if !has_claw_md {
             lines.push(
                 "  First run        /init scaffolds CLAW.md, .claw.json, and local session files"
+                    .to_string(),
+            );
+        }
+        if uses_github_copilot_startup_default(&self.model) {
+            lines.push(
+                "  Model source     GitHub Copilot login default · use /model to switch for this session"
                     .to_string(),
             );
         }
@@ -4168,8 +4262,10 @@ mod tests {
     use plugins::{PluginTool, PluginToolDefinition, PluginToolPermission};
     use runtime::{AssistantEvent, ContentBlock, ConversationMessage, MessageRole, PermissionMode};
     use serde_json::json;
+    use std::fs;
     use std::path::PathBuf;
-    use std::time::Duration;
+    use std::sync::{Mutex, OnceLock};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
     use tools::GlobalToolRegistry;
 
     fn registry_with_plugin_tool() -> GlobalToolRegistry {
@@ -4196,10 +4292,36 @@ mod tests {
         .expect("plugin tool registry should build")
     }
 
+    fn with_clean_config_home<T>(f: impl FnOnce() -> T) -> T {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        let _lock = LOCK
+            .get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let config_home = std::env::temp_dir().join(format!(
+            "claw-cli-test-home-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .expect("clock should move forward")
+                .as_nanos()
+        ));
+        fs::create_dir_all(&config_home).expect("temp config home should be created");
+        std::env::set_var("CLAW_CONFIG_HOME", &config_home);
+        let result = f();
+        std::env::remove_var("CLAW_CONFIG_HOME");
+        let _ = fs::remove_dir_all(config_home);
+        result
+    }
+
+    fn parse_args_isolated(args: &[String]) -> Result<CliAction, String> {
+        with_clean_config_home(|| parse_args(args))
+    }
+
     #[test]
     fn defaults_to_repl_when_no_args() {
         assert_eq!(
-            parse_args(&[]).expect("args should parse"),
+            parse_args_isolated(&[]).expect("args should parse"),
             CliAction::Repl {
                 model: DEFAULT_MODEL.to_string(),
                 allowed_tools: None,
@@ -4216,7 +4338,7 @@ mod tests {
             "world".to_string(),
         ];
         assert_eq!(
-            parse_args(&args).expect("args should parse"),
+            parse_args_isolated(&args).expect("args should parse"),
             CliAction::Prompt {
                 prompt: "hello world".to_string(),
                 model: DEFAULT_MODEL.to_string(),
@@ -4237,7 +4359,7 @@ mod tests {
             "this".to_string(),
         ];
         assert_eq!(
-            parse_args(&args).expect("args should parse"),
+            parse_args_isolated(&args).expect("args should parse"),
             CliAction::Prompt {
                 prompt: "explain this".to_string(),
                 model: "custom-opus".to_string(),
@@ -4257,7 +4379,7 @@ mod tests {
             "this".to_string(),
         ];
         assert_eq!(
-            parse_args(&args).expect("args should parse"),
+            parse_args_isolated(&args).expect("args should parse"),
             CliAction::Prompt {
                 prompt: "explain this".to_string(),
                 model: "claude-opus-4-6".to_string(),
@@ -4279,11 +4401,11 @@ mod tests {
     #[test]
     fn parses_version_flags_without_initializing_prompt_mode() {
         assert_eq!(
-            parse_args(&["--version".to_string()]).expect("args should parse"),
+            parse_args_isolated(&["--version".to_string()]).expect("args should parse"),
             CliAction::Version
         );
         assert_eq!(
-            parse_args(&["-V".to_string()]).expect("args should parse"),
+            parse_args_isolated(&["-V".to_string()]).expect("args should parse"),
             CliAction::Version
         );
     }
@@ -4292,7 +4414,7 @@ mod tests {
     fn parses_permission_mode_flag() {
         let args = vec!["--permission-mode=read-only".to_string()];
         assert_eq!(
-            parse_args(&args).expect("args should parse"),
+            parse_args_isolated(&args).expect("args should parse"),
             CliAction::Repl {
                 model: DEFAULT_MODEL.to_string(),
                 allowed_tools: None,
@@ -4309,7 +4431,7 @@ mod tests {
             "--allowed-tools=write_file".to_string(),
         ];
         assert_eq!(
-            parse_args(&args).expect("args should parse"),
+            parse_args_isolated(&args).expect("args should parse"),
             CliAction::Repl {
                 model: DEFAULT_MODEL.to_string(),
                 allowed_tools: Some(
@@ -4325,7 +4447,7 @@ mod tests {
 
     #[test]
     fn rejects_unknown_allowed_tools() {
-        let error = parse_args(&["--allowedTools".to_string(), "teleport".to_string()])
+        let error = parse_args_isolated(&["--allowedTools".to_string(), "teleport".to_string()])
             .expect_err("tool should be rejected");
         assert!(error.contains("unsupported tool in --allowedTools: teleport"));
     }
@@ -4340,7 +4462,7 @@ mod tests {
             "2026-04-01".to_string(),
         ];
         assert_eq!(
-            parse_args(&args).expect("args should parse"),
+            parse_args_isolated(&args).expect("args should parse"),
             CliAction::PrintSystemPrompt {
                 cwd: PathBuf::from("/tmp/project"),
                 date: "2026-04-01".to_string(),
@@ -4351,37 +4473,37 @@ mod tests {
     #[test]
     fn parses_login_and_logout_subcommands() {
         assert_eq!(
-            parse_args(&["login".to_string()]).expect("login should parse"),
+            parse_args_isolated(&["login".to_string()]).expect("login should parse"),
             CliAction::Login
         );
         assert_eq!(
-            parse_args(&["login-github-copilot".to_string()])
+            parse_args_isolated(&["login-github-copilot".to_string()])
                 .expect("login-github-copilot should parse"),
             CliAction::LoginGithubCopilot
         );
         assert_eq!(
-            parse_args(&["logout".to_string()]).expect("logout should parse"),
+            parse_args_isolated(&["logout".to_string()]).expect("logout should parse"),
             CliAction::Logout
         );
         assert_eq!(
-            parse_args(&["logout-github-copilot".to_string()])
+            parse_args_isolated(&["logout-github-copilot".to_string()])
                 .expect("logout-github-copilot should parse"),
             CliAction::LogoutGithubCopilot
         );
         assert_eq!(
-            parse_args(&["init".to_string()]).expect("init should parse"),
+            parse_args_isolated(&["init".to_string()]).expect("init should parse"),
             CliAction::Init
         );
         assert_eq!(
-            parse_args(&["agents".to_string()]).expect("agents should parse"),
+            parse_args_isolated(&["agents".to_string()]).expect("agents should parse"),
             CliAction::Agents { args: None }
         );
         assert_eq!(
-            parse_args(&["skills".to_string()]).expect("skills should parse"),
+            parse_args_isolated(&["skills".to_string()]).expect("skills should parse"),
             CliAction::Skills { args: None }
         );
         assert_eq!(
-            parse_args(&["agents".to_string(), "--help".to_string()])
+            parse_args_isolated(&["agents".to_string(), "--help".to_string()])
                 .expect("agents help should parse"),
             CliAction::Agents {
                 args: Some("--help".to_string())
@@ -4392,21 +4514,21 @@ mod tests {
     #[test]
     fn parses_direct_agents_and_skills_slash_commands() {
         assert_eq!(
-            parse_args(&["/agents".to_string()]).expect("/agents should parse"),
+            parse_args_isolated(&["/agents".to_string()]).expect("/agents should parse"),
             CliAction::Agents { args: None }
         );
         assert_eq!(
-            parse_args(&["/skills".to_string()]).expect("/skills should parse"),
+            parse_args_isolated(&["/skills".to_string()]).expect("/skills should parse"),
             CliAction::Skills { args: None }
         );
         assert_eq!(
-            parse_args(&["/skills".to_string(), "help".to_string()])
+            parse_args_isolated(&["/skills".to_string(), "help".to_string()])
                 .expect("/skills help should parse"),
             CliAction::Skills {
                 args: Some("help".to_string())
             }
         );
-        let error = parse_args(&["/status".to_string()])
+        let error = parse_args_isolated(&["/status".to_string()])
             .expect_err("/status should remain REPL-only when invoked directly");
         assert!(error.contains("Direct slash command unavailable"));
         assert!(error.contains("/status"));
@@ -4420,7 +4542,7 @@ mod tests {
             "/compact".to_string(),
         ];
         assert_eq!(
-            parse_args(&args).expect("args should parse"),
+            parse_args_isolated(&args).expect("args should parse"),
             CliAction::ResumeSession {
                 session_path: PathBuf::from("session.json"),
                 commands: vec!["/compact".to_string()],
@@ -4438,7 +4560,7 @@ mod tests {
             "/cost".to_string(),
         ];
         assert_eq!(
-            parse_args(&args).expect("args should parse"),
+            parse_args_isolated(&args).expect("args should parse"),
             CliAction::ResumeSession {
                 session_path: PathBuf::from("session.json"),
                 commands: vec![

--- a/rust/crates/claw-cli/src/main.rs
+++ b/rust/crates/claw-cli/src/main.rs
@@ -16,11 +16,12 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use api::{
-    load_saved_github_token, poll_for_github_copilot_access_token,
+    cached_model_availability_is_fresh, load_cached_model_availability, load_saved_github_token,
+    poll_for_github_copilot_access_token, refresh_github_copilot_model_availability,
     request_github_copilot_device_code, save_github_copilot_token, AuthSource, ClawApiClient,
-    ContentBlockDelta, InputContentBlock, InputMessage, MessageRequest, MessageResponse,
-    OutputContentBlock, ProviderClient, StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition,
-    ToolResultContentBlock,
+    ContentBlockDelta, GithubCopilotModelAvailability, InputContentBlock, InputMessage,
+    MessageRequest, MessageResponse, OutputContentBlock, ProviderClient,
+    StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
 };
 
 use commands::{
@@ -441,6 +442,27 @@ fn uses_github_copilot_startup_default(model: &str) -> bool {
         })
 }
 
+fn copilot_model_availability_for_report(model: &str) -> Option<GithubCopilotModelAvailability> {
+    if !model.starts_with("github-copilot/") {
+        return None;
+    }
+    match load_cached_model_availability() {
+        Ok(Some(cache)) if cached_model_availability_is_fresh(&cache) => Some(cache),
+        Ok(_) => {
+            let runtime = tokio::runtime::Runtime::new().ok()?;
+            runtime.block_on(refresh_github_copilot_model_availability()).ok()
+        }
+        Err(_) => None,
+    }
+}
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
 fn normalize_allowed_tools(values: &[String]) -> Result<Option<AllowedToolSet>, String> {
     current_tool_registry()?.normalize_allowed_tools(values)
 }
@@ -634,6 +656,7 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
         remember_startup_default_model(DEFAULT_GITHUB_COPILOT_MODEL)?;
         let runtime = tokio::runtime::Runtime::new()?;
         let resolved = runtime.block_on(api::resolve_github_copilot_runtime_auth())?;
+        let availability = runtime.block_on(refresh_github_copilot_model_availability()).ok();
         let expires_in_minutes = resolved.expires_at.saturating_sub(
             SystemTime::now()
                 .duration_since(UNIX_EPOCH)
@@ -643,6 +666,12 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
         println!("GitHub Copilot credentials already available.");
         println!("Cached Copilot token source: {}", resolved.source);
         println!("Cached Copilot token expires in ~{expires_in_minutes} minutes.");
+        if let Some(availability) = availability {
+            println!(
+                "Detected available Copilot models: {}",
+                availability.available.join(", ")
+            );
+        }
         println!(
             "Future `claw` launches will default to {DEFAULT_GITHUB_COPILOT_MODEL}. Use `--model` or `/model` to override."
         );
@@ -664,6 +693,7 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
     save_github_copilot_token(&github_token)?;
     remember_startup_default_model(DEFAULT_GITHUB_COPILOT_MODEL)?;
     let resolved = runtime.block_on(api::resolve_github_copilot_runtime_auth())?;
+    let availability = runtime.block_on(refresh_github_copilot_model_availability()).ok();
     let expires_in_minutes = resolved.expires_at.saturating_sub(
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -674,6 +704,12 @@ fn run_login_github_copilot() -> Result<(), Box<dyn std::error::Error>> {
     println!("GitHub Copilot login complete.");
     println!("Cached Copilot token source: {}", resolved.source);
     println!("Cached Copilot token expires in ~{expires_in_minutes} minutes.");
+    if let Some(availability) = availability {
+        println!(
+            "Detected available Copilot models: {}",
+            availability.available.join(", ")
+        );
+    }
     println!(
         "Future `claw` launches will default to {DEFAULT_GITHUB_COPILOT_MODEL}. Use `--model` or `/model` to override."
     );
@@ -830,8 +866,13 @@ struct StatusUsage {
     estimated_tokens: usize,
 }
 
-fn format_model_report(model: &str, message_count: usize, turns: u32) -> String {
-    format!(
+fn format_model_report(
+    model: &str,
+    message_count: usize,
+    turns: u32,
+    copilot_availability: Option<&GithubCopilotModelAvailability>,
+) -> String {
+    let mut report = format!(
         "Model
   Current          {model}
   Session          {message_count} messages · {turns} turns
@@ -846,7 +887,27 @@ Aliases
 Next
   /model           Show the current model
   /model <name>    Switch models for this REPL session"
-    )
+    );
+    if let Some(cache) = copilot_availability {
+        let available = if cache.available.is_empty() {
+            "(none detected)".to_string()
+        } else {
+            cache.available.join(", ")
+        };
+        let checked_ago_minutes = now_ms().saturating_sub(cache.checked_at) / 60_000;
+        report.push_str(&format!(
+            "\n\nGitHub Copilot
+  Available        {available}
+  Checked          {checked_ago_minutes} minute(s) ago"
+        ));
+        if !cache.unavailable.is_empty() {
+            report.push_str(&format!(
+                "\n  Unavailable      {}",
+                cache.unavailable.join(", ")
+            ));
+        }
+    }
+    report
 }
 
 fn format_model_switch_report(previous: &str, next: &str, message_count: usize) -> String {
@@ -1524,12 +1585,14 @@ impl LiveCli {
 
     fn set_model(&mut self, model: Option<String>) -> Result<bool, Box<dyn std::error::Error>> {
         let Some(model) = model else {
+            let availability = copilot_model_availability_for_report(&self.model);
             println!(
                 "{}",
                 format_model_report(
                     &self.model,
                     self.runtime.session().messages.len(),
                     self.runtime.usage().turns(),
+                    availability.as_ref(),
                 )
             );
             return Ok(false);
@@ -1538,12 +1601,14 @@ impl LiveCli {
         let model = resolve_model_alias(&model).to_string();
 
         if model == self.model {
+            let availability = copilot_model_availability_for_report(&self.model);
             println!(
                 "{}",
                 format_model_report(
                     &self.model,
                     self.runtime.session().messages.len(),
                     self.runtime.usage().turns(),
+                    availability.as_ref(),
                 )
             );
             return Ok(false);
@@ -4743,7 +4808,7 @@ mod tests {
 
     #[test]
     fn model_report_uses_sectioned_layout() {
-        let report = format_model_report("sonnet", 12, 4);
+        let report = format_model_report("sonnet", 12, 4, None);
         assert!(report.contains("Model"));
         assert!(report.contains("Current          sonnet"));
         assert!(report.contains("Session          12 messages · 4 turns"));

--- a/rust/crates/claw-cli/src/main.rs
+++ b/rust/crates/claw-cli/src/main.rs
@@ -877,7 +877,7 @@ fn format_model_report(
   Current          {model}
   Session          {message_count} messages · {turns} turns
 
-Aliases
+Quick picks
   opus             claude-opus-4-6
   sonnet           claude-sonnet-4-6
   haiku            claude-haiku-4-5-20251213
@@ -889,22 +889,24 @@ Next
   /model <name>    Switch models for this REPL session"
     );
     if let Some(cache) = copilot_availability {
-        let available = if cache.available.is_empty() {
-            "(none detected)".to_string()
-        } else {
-            cache.available.join(", ")
-        };
         let checked_ago_minutes = now_ms().saturating_sub(cache.checked_at) / 60_000;
         report.push_str(&format!(
             "\n\nGitHub Copilot
-  Available        {available}
   Checked          {checked_ago_minutes} minute(s) ago"
         ));
+        if cache.available.is_empty() {
+            report.push_str("\n  Available        (none detected)");
+        } else {
+            report.push_str("\n  Available");
+            for model_id in &cache.available {
+                report.push_str(&format!("\n  - github-copilot/{model_id}"));
+            }
+        }
         if !cache.unavailable.is_empty() {
-            report.push_str(&format!(
-                "\n  Unavailable      {}",
-                cache.unavailable.join(", ")
-            ));
+            report.push_str("\n\nNot available on this account");
+            for model_id in &cache.unavailable {
+                report.push_str(&format!("\n  - github-copilot/{model_id}"));
+            }
         }
     }
     report
@@ -4315,7 +4317,7 @@ mod tests {
         describe_tool_progress, filter_tool_specs, format_compact_report, format_cost_report,
         format_internal_prompt_progress_line, format_model_report, format_model_switch_report,
         format_permissions_report, format_permissions_switch_report, format_resume_report,
-        format_status_report, format_tool_call_start, format_tool_result,
+        format_status_report, format_tool_call_start, format_tool_result, now_ms,
         normalize_permission_mode, parse_args, parse_git_status_metadata, permission_policy,
         print_help_to, push_output_block, render_config_report, render_memory_report,
         render_repl_help, render_unknown_repl_command, resolve_model_alias, response_to_events,
@@ -4323,7 +4325,7 @@ mod tests {
         CliAction, CliOutputFormat, InternalPromptProgressEvent, InternalPromptProgressState,
         SlashCommand, StatusUsage, DEFAULT_MODEL,
     };
-    use api::{MessageResponse, OutputContentBlock, Usage};
+    use api::{GithubCopilotModelAvailability, MessageResponse, OutputContentBlock, Usage};
     use plugins::{PluginTool, PluginToolDefinition, PluginToolPermission};
     use runtime::{AssistantEvent, ContentBlock, ConversationMessage, MessageRole, PermissionMode};
     use serde_json::json;
@@ -4812,8 +4814,28 @@ mod tests {
         assert!(report.contains("Model"));
         assert!(report.contains("Current          sonnet"));
         assert!(report.contains("Session          12 messages · 4 turns"));
-        assert!(report.contains("Aliases"));
+        assert!(report.contains("Quick picks"));
         assert!(report.contains("/model <name>    Switch models for this REPL session"));
+    }
+
+    #[test]
+    fn model_report_lists_detected_copilot_models() {
+        let report = format_model_report(
+            "github-copilot/gpt-5.4",
+            0,
+            0,
+            Some(&GithubCopilotModelAvailability {
+                checked_at: now_ms(),
+                available: vec!["gpt-5.4".to_string(), "gpt-4o".to_string()],
+                unavailable: vec!["o1".to_string()],
+            }),
+        );
+        assert!(report.contains("GitHub Copilot"));
+        assert!(report.contains("Available"));
+        assert!(report.contains("github-copilot/gpt-5.4"));
+        assert!(report.contains("github-copilot/gpt-4o"));
+        assert!(report.contains("Not available on this account"));
+        assert!(report.contains("github-copilot/o1"));
     }
 
     #[test]

--- a/rust/crates/claw-cli/src/main.rs
+++ b/rust/crates/claw-cli/src/main.rs
@@ -18,10 +18,11 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use api::{
     cached_model_availability_is_fresh, load_cached_model_availability, load_saved_github_token,
     poll_for_github_copilot_access_token, refresh_github_copilot_model_availability,
-    request_github_copilot_device_code, save_github_copilot_token, AuthSource, ClawApiClient,
-    ContentBlockDelta, GithubCopilotModelAvailability, InputContentBlock, InputMessage,
-    MessageRequest, MessageResponse, OutputContentBlock, ProviderClient,
-    StreamEvent as ApiStreamEvent, ToolChoice, ToolDefinition, ToolResultContentBlock,
+    request_github_copilot_device_code, resolve_startup_auth_source,
+    save_github_copilot_token, AuthSource, ClawApiClient, ContentBlockDelta,
+    GithubCopilotModelAvailability, InputContentBlock, InputMessage, MessageRequest,
+    MessageResponse, OutputContentBlock, ProviderClient, StreamEvent as ApiStreamEvent,
+    ToolChoice, ToolDefinition, ToolResultContentBlock,
 };
 
 use commands::{
@@ -48,11 +49,7 @@ use tools::GlobalToolRegistry;
 const DEFAULT_MODEL: &str = "claude-opus-4-6";
 const DEFAULT_GITHUB_COPILOT_MODEL: &str = "github-copilot/gpt-5.4";
 fn max_tokens_for_model(model: &str) -> u32 {
-    if model.contains("opus") {
-        32_000
-    } else {
-        64_000
-    }
+    api::max_tokens_for_model(model)
 }
 const DEFAULT_DATE: &str = "2026-03-31";
 const DEFAULT_OAUTH_CALLBACK_PORT: u16 = 4545;
@@ -3268,7 +3265,10 @@ impl DefaultRuntimeClient {
     ) -> Result<Self, Box<dyn std::error::Error>> {
         Ok(Self {
             runtime: tokio::runtime::Runtime::new()?,
-            client: ProviderClient::from_model(&model)?,
+            client: ProviderClient::from_model_with_default_auth(
+                &model,
+                Some(resolve_cli_auth_source()?),
+            )?,
             model,
             enable_tools,
             emit_output,
@@ -3277,6 +3277,16 @@ impl DefaultRuntimeClient {
             progress_reporter,
         })
     }
+}
+
+fn resolve_cli_auth_source() -> Result<AuthSource, Box<dyn std::error::Error>> {
+    Ok(resolve_startup_auth_source(|| {
+        let cwd = env::current_dir().map_err(api::ApiError::from)?;
+        let config = ConfigLoader::default_for(&cwd).load().map_err(|error| {
+            api::ApiError::Auth(format!("failed to load runtime OAuth config: {error}"))
+        })?;
+        Ok(config.oauth().cloned())
+    })?)
 }
 
 impl ApiClient for DefaultRuntimeClient {

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -66,7 +66,7 @@ pub use oauth::{
     loopback_redirect_uri, parse_oauth_callback_query, parse_oauth_callback_request_target,
     save_credentials_entry, save_oauth_credentials, OAuthAuthorizationRequest, OAuthCallbackParams,
     OAuthRefreshRequest, OAuthTokenExchangeRequest, OAuthTokenSet, PkceChallengeMethod,
-    PkceCodePair,
+    PkceCodePair, StartupPreferences,
 };
 pub use permissions::{
     PermissionMode, PermissionOutcome, PermissionPolicy, PermissionPromptDecision,

--- a/rust/crates/runtime/src/lib.rs
+++ b/rust/crates/runtime/src/lib.rs
@@ -17,10 +17,6 @@ pub mod sandbox;
 mod session;
 mod usage;
 
-pub use lsp::{
-    FileDiagnostics, LspContextEnrichment, LspError, LspManager, LspServerConfig,
-    SymbolLocation, WorkspaceDiagnostics,
-};
 pub use bash::{execute_bash, BashCommandInput, BashCommandOutput};
 pub use bootstrap::{BootstrapPhase, BootstrapPlan};
 pub use compact::{
@@ -28,8 +24,8 @@ pub use compact::{
     get_compact_continuation_message, should_compact, CompactionConfig, CompactionResult,
 };
 pub use config::{
-    ConfigEntry, ConfigError, ConfigLoader, ConfigSource, McpManagedProxyServerConfig,
-    McpConfigCollection, McpOAuthConfig, McpRemoteServerConfig, McpSdkServerConfig,
+    ConfigEntry, ConfigError, ConfigLoader, ConfigSource, McpConfigCollection,
+    McpManagedProxyServerConfig, McpOAuthConfig, McpRemoteServerConfig, McpSdkServerConfig,
     McpServerConfig, McpStdioServerConfig, McpTransport, McpWebSocketServerConfig, OAuthConfig,
     ResolvedPermissionMode, RuntimeConfig, RuntimeFeatureConfig, RuntimeHookConfig,
     RuntimePluginConfig, ScopedMcpServerConfig, CLAW_SETTINGS_SCHEMA_NAME,
@@ -44,12 +40,16 @@ pub use file_ops::{
     WriteFileOutput,
 };
 pub use hooks::{HookEvent, HookRunResult, HookRunner};
+pub use lsp::{
+    FileDiagnostics, LspContextEnrichment, LspError, LspManager, LspServerConfig, SymbolLocation,
+    WorkspaceDiagnostics,
+};
 pub use mcp::{
     mcp_server_signature, mcp_tool_name, mcp_tool_prefix, normalize_name_for_mcp,
     scoped_mcp_config_hash, unwrap_ccr_proxy_url,
 };
 pub use mcp_client::{
-    McpManagedProxyTransport, McpClientAuth, McpClientBootstrap, McpClientTransport,
+    McpClientAuth, McpClientBootstrap, McpClientTransport, McpManagedProxyTransport,
     McpRemoteTransport, McpSdkTransport, McpStdioTransport,
 };
 pub use mcp_stdio::{
@@ -61,11 +61,12 @@ pub use mcp_stdio::{
     McpToolCallContent, McpToolCallParams, McpToolCallResult, UnsupportedMcpServer,
 };
 pub use oauth::{
-    clear_oauth_credentials, code_challenge_s256, credentials_path, generate_pkce_pair,
-    generate_state, load_oauth_credentials, loopback_redirect_uri, parse_oauth_callback_query,
-    parse_oauth_callback_request_target, save_oauth_credentials, OAuthAuthorizationRequest,
-    OAuthCallbackParams, OAuthRefreshRequest, OAuthTokenExchangeRequest, OAuthTokenSet,
-    PkceChallengeMethod, PkceCodePair,
+    clear_credentials_entry, clear_oauth_credentials, code_challenge_s256, credentials_path,
+    generate_pkce_pair, generate_state, load_credentials_entry, load_oauth_credentials,
+    loopback_redirect_uri, parse_oauth_callback_query, parse_oauth_callback_request_target,
+    save_credentials_entry, save_oauth_credentials, OAuthAuthorizationRequest, OAuthCallbackParams,
+    OAuthRefreshRequest, OAuthTokenExchangeRequest, OAuthTokenSet, PkceChallengeMethod,
+    PkceCodePair,
 };
 pub use permissions::{
     PermissionMode, PermissionOutcome, PermissionPolicy, PermissionPromptDecision,

--- a/rust/crates/runtime/src/oauth.rs
+++ b/rust/crates/runtime/src/oauth.rs
@@ -3,6 +3,7 @@ use std::fs::{self, File};
 use std::io::{self, Read};
 use std::path::PathBuf;
 
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use sha2::{Digest, Sha256};
@@ -259,36 +260,54 @@ pub fn credentials_path() -> io::Result<PathBuf> {
     Ok(credentials_home_dir()?.join("credentials.json"))
 }
 
-pub fn load_oauth_credentials() -> io::Result<Option<OAuthTokenSet>> {
+pub fn load_credentials_entry<T>(key: &str) -> io::Result<Option<T>>
+where
+    T: DeserializeOwned,
+{
     let path = credentials_path()?;
     let root = read_credentials_root(&path)?;
-    let Some(oauth) = root.get("oauth") else {
+    let Some(value) = root.get(key) else {
         return Ok(None);
     };
-    if oauth.is_null() {
+    if value.is_null() {
         return Ok(None);
     }
-    let stored = serde_json::from_value::<StoredOAuthCredentials>(oauth.clone())
-        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
-    Ok(Some(stored.into()))
+    serde_json::from_value::<T>(value.clone())
+        .map(Some)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))
 }
 
-pub fn save_oauth_credentials(token_set: &OAuthTokenSet) -> io::Result<()> {
+pub fn save_credentials_entry<T>(key: &str, value: &T) -> io::Result<()>
+where
+    T: Serialize,
+{
     let path = credentials_path()?;
     let mut root = read_credentials_root(&path)?;
     root.insert(
-        "oauth".to_string(),
-        serde_json::to_value(StoredOAuthCredentials::from(token_set.clone()))
+        key.to_string(),
+        serde_json::to_value(value)
             .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?,
     );
     write_credentials_root(&path, &root)
 }
 
-pub fn clear_oauth_credentials() -> io::Result<()> {
+pub fn clear_credentials_entry(key: &str) -> io::Result<()> {
     let path = credentials_path()?;
     let mut root = read_credentials_root(&path)?;
-    root.remove("oauth");
+    root.remove(key);
     write_credentials_root(&path, &root)
+}
+
+pub fn load_oauth_credentials() -> io::Result<Option<OAuthTokenSet>> {
+    load_credentials_entry::<StoredOAuthCredentials>("oauth").map(|value| value.map(Into::into))
+}
+
+pub fn save_oauth_credentials(token_set: &OAuthTokenSet) -> io::Result<()> {
+    save_credentials_entry("oauth", &StoredOAuthCredentials::from(token_set.clone()))
+}
+
+pub fn clear_oauth_credentials() -> io::Result<()> {
+    clear_credentials_entry("oauth")
 }
 
 pub fn parse_oauth_callback_request_target(target: &str) -> Result<OAuthCallbackParams, String> {

--- a/rust/crates/runtime/src/oauth.rs
+++ b/rust/crates/runtime/src/oauth.rs
@@ -89,6 +89,12 @@ struct StoredOAuthCredentials {
     scopes: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StartupPreferences {
+    #[serde(default)]
+    pub default_model: Option<String>,
+}
+
 impl From<OAuthTokenSet> for StoredOAuthCredentials {
     fn from(value: OAuthTokenSet) -> Self {
         Self {

--- a/rust/crates/runtime/src/oauth.rs
+++ b/rust/crates/runtime/src/oauth.rs
@@ -381,7 +381,20 @@ fn write_credentials_root(path: &PathBuf, root: &Map<String, Value>) -> io::Resu
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let temp_path = path.with_extension("json.tmp");
     fs::write(&temp_path, format!("{rendered}\n"))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600))?;
+    }
     fs::rename(temp_path, path)
+        .and_then(|()| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                fs::set_permissions(path, fs::Permissions::from_mode(0o600))?;
+            }
+            Ok(())
+        })
 }
 
 fn base64url_encode(bytes: &[u8]) -> String {

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -14,7 +14,8 @@ use runtime::{
     edit_file, execute_bash, glob_search, grep_search, load_credentials_entry, load_system_prompt,
     read_file, write_file, ApiClient, ApiRequest, AssistantEvent, BashCommandInput, ContentBlock,
     ConversationMessage, ConversationRuntime, GrepSearchInput, MessageRole, PermissionMode,
-    PermissionPolicy, RuntimeError, Session, TokenUsage, ToolError, ToolExecutor,
+    PermissionPolicy, RuntimeError, Session, StartupPreferences, TokenUsage, ToolError,
+    ToolExecutor,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -1512,12 +1513,6 @@ fn resolve_skill_path(skill: &str) -> Result<std::path::PathBuf, String> {
 const DEFAULT_AGENT_MODEL: &str = "claude-opus-4-6";
 const DEFAULT_AGENT_SYSTEM_DATE: &str = "2026-03-31";
 const DEFAULT_AGENT_MAX_ITERATIONS: usize = 32;
-
-#[derive(Debug, Clone, Deserialize)]
-struct StartupPreferences {
-    #[serde(default)]
-    default_model: Option<String>,
-}
 
 fn execute_agent(input: AgentInput) -> Result<AgentOutput, String> {
     execute_agent_with_spawn(input, spawn_agent_job)
@@ -3133,6 +3128,22 @@ mod tests {
         }
     }
 
+    struct ScopedTempDir {
+        path: PathBuf,
+    }
+
+    impl ScopedTempDir {
+        fn new(path: PathBuf) -> Self {
+            Self { path }
+        }
+    }
+
+    impl Drop for ScopedTempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
     fn temp_path(name: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -3577,8 +3588,10 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = temp_path("agent-store");
         let config_home = temp_path("agent-config-home");
+        let _dir_guard = ScopedTempDir::new(dir.clone());
+        let _config_home_dir_guard = ScopedTempDir::new(config_home.clone());
         let _agent_store_guard = ScopedEnvVar::set("CLAW_AGENT_STORE", &dir);
-        let _config_home_guard = ScopedEnvVar::set("CLAW_CONFIG_HOME", &config_home);
+        let _config_home_env_guard = ScopedEnvVar::set("CLAW_CONFIG_HOME", &config_home);
         let captured = Arc::new(Mutex::new(None::<AgentJob>));
         let captured_for_spawn = Arc::clone(&captured);
 
@@ -3652,8 +3665,6 @@ mod tests {
         .expect("Agent should normalize explicit names");
         let named_output: serde_json::Value = serde_json::from_str(&named).expect("valid json");
         assert_eq!(named_output["name"], "ship-audit");
-        let _ = std::fs::remove_dir_all(dir);
-        let _ = std::fs::remove_dir_all(config_home);
     }
 
     #[test]

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -3554,6 +3554,8 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = temp_path("agent-store");
         let config_home = temp_path("agent-config-home");
+        let previous_agent_store = std::env::var_os("CLAW_AGENT_STORE");
+        let previous_config_home = std::env::var_os("CLAW_CONFIG_HOME");
         std::env::set_var("CLAW_AGENT_STORE", &dir);
         std::env::set_var("CLAW_CONFIG_HOME", &config_home);
         let captured = Arc::new(Mutex::new(None::<AgentJob>));
@@ -3581,8 +3583,16 @@ mod tests {
             },
         )
         .expect("Agent should succeed");
-        std::env::remove_var("CLAW_AGENT_STORE");
-        std::env::remove_var("CLAW_CONFIG_HOME");
+        if let Some(previous) = previous_agent_store {
+            std::env::set_var("CLAW_AGENT_STORE", previous);
+        } else {
+            std::env::remove_var("CLAW_AGENT_STORE");
+        }
+        if let Some(previous) = previous_config_home {
+            std::env::set_var("CLAW_CONFIG_HOME", previous);
+        } else {
+            std::env::remove_var("CLAW_CONFIG_HOME");
+        }
 
         assert_eq!(manifest.name, "ship-audit");
         assert_eq!(manifest.subagent_type.as_deref(), Some("Explore"));

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -11,10 +11,10 @@ use api::{
 use plugins::PluginTool;
 use reqwest::blocking::Client;
 use runtime::{
-    edit_file, execute_bash, glob_search, grep_search, load_system_prompt, read_file, write_file,
-    ApiClient, ApiRequest, AssistantEvent, BashCommandInput, ContentBlock, ConversationMessage,
-    ConversationRuntime, GrepSearchInput, MessageRole, PermissionMode, PermissionPolicy,
-    RuntimeError, Session, TokenUsage, ToolError, ToolExecutor,
+    edit_file, execute_bash, glob_search, grep_search, load_credentials_entry, load_system_prompt,
+    read_file, write_file, ApiClient, ApiRequest, AssistantEvent, BashCommandInput, ContentBlock,
+    ConversationMessage, ConversationRuntime, GrepSearchInput, MessageRole, PermissionMode,
+    PermissionPolicy, RuntimeError, Session, TokenUsage, ToolError, ToolExecutor,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -1513,6 +1513,12 @@ const DEFAULT_AGENT_MODEL: &str = "claude-opus-4-6";
 const DEFAULT_AGENT_SYSTEM_DATE: &str = "2026-03-31";
 const DEFAULT_AGENT_MAX_ITERATIONS: usize = 32;
 
+#[derive(Debug, Clone, Deserialize)]
+struct StartupPreferences {
+    #[serde(default)]
+    default_model: Option<String>,
+}
+
 fn execute_agent(input: AgentInput) -> Result<AgentOutput, String> {
     execute_agent_with_spawn(input, spawn_agent_job)
 }
@@ -1669,8 +1675,17 @@ fn resolve_agent_model(model: Option<&str>) -> String {
     model
         .map(str::trim)
         .filter(|model| !model.is_empty())
-        .unwrap_or(DEFAULT_AGENT_MODEL)
-        .to_string()
+        .map(ToOwned::to_owned)
+        .or_else(resolve_startup_default_agent_model)
+        .unwrap_or_else(|| DEFAULT_AGENT_MODEL.to_string())
+}
+
+fn resolve_startup_default_agent_model() -> Option<String> {
+    load_credentials_entry::<StartupPreferences>("startupPreferences")
+        .ok()
+        .and_then(std::convert::identity)
+        .and_then(|preferences| preferences.default_model)
+        .filter(|model| !model.trim().is_empty())
 }
 
 fn allowed_tools_for_subagent(subagent_type: &str) -> BTreeSet<String> {
@@ -3538,9 +3553,17 @@ mod tests {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = temp_path("agent-store");
+        let config_home = temp_path("agent-config-home");
         std::env::set_var("CLAW_AGENT_STORE", &dir);
+        std::env::set_var("CLAW_CONFIG_HOME", &config_home);
         let captured = Arc::new(Mutex::new(None::<AgentJob>));
         let captured_for_spawn = Arc::clone(&captured);
+
+        runtime::save_credentials_entry(
+            "startupPreferences",
+            &json!({"default_model": "github-copilot/gpt-5.4"}),
+        )
+        .expect("startup preference should be written");
 
         let manifest = execute_agent_with_spawn(
             AgentInput {
@@ -3559,6 +3582,7 @@ mod tests {
         )
         .expect("Agent should succeed");
         std::env::remove_var("CLAW_AGENT_STORE");
+        std::env::remove_var("CLAW_CONFIG_HOME");
 
         assert_eq!(manifest.name, "ship-audit");
         assert_eq!(manifest.subagent_type.as_deref(), Some("Explore"));
@@ -3573,6 +3597,7 @@ mod tests {
         assert!(contents.contains("Check tests and outstanding work."));
         assert!(manifest_contents.contains("\"subagentType\": \"Explore\""));
         assert!(manifest_contents.contains("\"status\": \"running\""));
+        assert!(manifest_contents.contains("\"model\": \"github-copilot/gpt-5.4\""));
         let captured_job = captured
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -3607,6 +3632,7 @@ mod tests {
         let named_output: serde_json::Value = serde_json::from_str(&named).expect("valid json");
         assert_eq!(named_output["name"], "ship-audit");
         let _ = std::fs::remove_dir_all(dir);
+        let _ = std::fs::remove_dir_all(config_home);
     }
 
     #[test]

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -91,7 +91,10 @@ impl GlobalToolRegistry {
         Ok(Self { plugin_tools })
     }
 
-    pub fn normalize_allowed_tools(&self, values: &[String]) -> Result<Option<BTreeSet<String>>, String> {
+    pub fn normalize_allowed_tools(
+        &self,
+        values: &[String],
+    ) -> Result<Option<BTreeSet<String>>, String> {
         if values.is_empty() {
             return Ok(None);
         }
@@ -100,7 +103,11 @@ impl GlobalToolRegistry {
         let canonical_names = builtin_specs
             .iter()
             .map(|spec| spec.name.to_string())
-            .chain(self.plugin_tools.iter().map(|tool| tool.definition().name.clone()))
+            .chain(
+                self.plugin_tools
+                    .iter()
+                    .map(|tool| tool.definition().name.clone()),
+            )
             .collect::<Vec<_>>();
         let mut name_map = canonical_names
             .iter()
@@ -151,7 +158,8 @@ impl GlobalToolRegistry {
             .plugin_tools
             .iter()
             .filter(|tool| {
-                allowed_tools.is_none_or(|allowed| allowed.contains(tool.definition().name.as_str()))
+                allowed_tools
+                    .is_none_or(|allowed| allowed.contains(tool.definition().name.as_str()))
             })
             .map(|tool| ToolDefinition {
                 name: tool.definition().name.clone(),
@@ -174,7 +182,8 @@ impl GlobalToolRegistry {
             .plugin_tools
             .iter()
             .filter(|tool| {
-                allowed_tools.is_none_or(|allowed| allowed.contains(tool.definition().name.as_str()))
+                allowed_tools
+                    .is_none_or(|allowed| allowed.contains(tool.definition().name.as_str()))
             })
             .map(|tool| {
                 (
@@ -498,6 +507,8 @@ pub fn mvp_tool_specs() -> Vec<ToolSpec> {
             description: "Return structured output in the requested format.",
             input_schema: json!({
                 "type": "object",
+                "properties": {},
+                "required": [],
                 "additionalProperties": true
             }),
             required_permission: PermissionMode::ReadOnly,

--- a/rust/crates/tools/src/lib.rs
+++ b/rust/crates/tools/src/lib.rs
@@ -3110,6 +3110,29 @@ mod tests {
         LOCK.get_or_init(|| Mutex::new(()))
     }
 
+    struct ScopedEnvVar {
+        key: &'static str,
+        previous: Option<std::ffi::OsString>,
+    }
+
+    impl ScopedEnvVar {
+        fn set(key: &'static str, value: &std::path::Path) -> Self {
+            let previous = std::env::var_os(key);
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for ScopedEnvVar {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                std::env::set_var(self.key, previous);
+            } else {
+                std::env::remove_var(self.key);
+            }
+        }
+    }
+
     fn temp_path(name: &str) -> PathBuf {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -3554,10 +3577,8 @@ mod tests {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let dir = temp_path("agent-store");
         let config_home = temp_path("agent-config-home");
-        let previous_agent_store = std::env::var_os("CLAW_AGENT_STORE");
-        let previous_config_home = std::env::var_os("CLAW_CONFIG_HOME");
-        std::env::set_var("CLAW_AGENT_STORE", &dir);
-        std::env::set_var("CLAW_CONFIG_HOME", &config_home);
+        let _agent_store_guard = ScopedEnvVar::set("CLAW_AGENT_STORE", &dir);
+        let _config_home_guard = ScopedEnvVar::set("CLAW_CONFIG_HOME", &config_home);
         let captured = Arc::new(Mutex::new(None::<AgentJob>));
         let captured_for_spawn = Arc::clone(&captured);
 
@@ -3583,16 +3604,6 @@ mod tests {
             },
         )
         .expect("Agent should succeed");
-        if let Some(previous) = previous_agent_store {
-            std::env::set_var("CLAW_AGENT_STORE", previous);
-        } else {
-            std::env::remove_var("CLAW_AGENT_STORE");
-        }
-        if let Some(previous) = previous_config_home {
-            std::env::set_var("CLAW_CONFIG_HOME", previous);
-        } else {
-            std::env::remove_var("CLAW_CONFIG_HOME");
-        }
 
         assert_eq!(manifest.name, "ship-audit");
         assert_eq!(manifest.subagent_type.as_deref(), Some("Explore"));

--- a/rust/docs/github-copilot-compat.md
+++ b/rust/docs/github-copilot-compat.md
@@ -1,0 +1,202 @@
+# GitHub Copilot Compatibility
+
+This document explains the GitHub Copilot compatibility layer added to the Rust CLI, how it fits into the current architecture, what was changed, and what was validated.
+
+## Outcome
+
+The Rust CLI now supports GitHub Copilot as a first-class provider without replacing the existing Anthropic/xAI/OpenAI paths.
+
+For a normal user, the intended flow is:
+
+1. Run `claw login-github-copilot`
+2. Approve the GitHub device flow once
+3. Launch `claw`
+4. Start chatting on the Copilot-backed default model automatically
+
+The system also:
+
+- detects which Copilot models the current account can actually use
+- shows that information in the UX
+- keeps explicit `--model` and `/model` overrides working
+- makes subagents inherit the active default model instead of falling back to Anthropic
+
+## System Map
+
+```mermaid
+mindmap
+  root((GitHub Copilot Compat))
+    Auth
+      Device flow login
+      GitHub token persisted in ~/.claw/credentials.json
+      Runtime Copilot token exchange
+      Optional ~/.openclaw compatibility fallback
+    Provider runtime
+      ProviderKind::GithubCopilot
+      OpenAI-compatible transport
+      Copilot-specific headers
+      Dynamic base URL from proxy-ep
+      gpt-5.x max_completion_tokens handling
+    UX
+      claw login-github-copilot
+      claw startup defaults to Copilot after login
+      startup banner explains model source
+      /model shows quick picks
+      /model shows available and unavailable Copilot models
+    Delegation
+      Agent tool inherits persisted default model
+      Subagents no longer default to Anthropic when main CLI uses Copilot
+```
+
+## Architecture
+
+### 1. Auth and credential storage
+
+Files involved:
+
+- [crates/api/src/providers/github_copilot.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/api/src/providers/github_copilot.rs)
+- [crates/runtime/src/oauth.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/runtime/src/oauth.rs)
+
+Implemented pieces:
+
+- GitHub device-flow login using GitHub's device endpoints
+- GitHub token persistence under `~/.claw/credentials.json`
+- runtime Copilot token exchange via `https://api.github.com/copilot_internal/v2/token`
+- runtime token caching with expiry buffer
+- optional fallback to `~/.openclaw` state when present on the local machine
+
+Credential store keys introduced:
+
+- `githubCopilot`
+- `githubCopilotRuntime`
+- `githubCopilotModelAvailability`
+- `startupPreferences`
+
+### 2. Provider routing
+
+Files involved:
+
+- [crates/api/src/providers/mod.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/api/src/providers/mod.rs)
+- [crates/api/src/client.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/api/src/client.rs)
+- [crates/api/src/providers/openai_compat.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/api/src/providers/openai_compat.rs)
+
+Implemented pieces:
+
+- added `ProviderKind::GithubCopilot`
+- accepted `github-copilot/<model-id>` refs
+- normalized Copilot requests onto the OpenAI-compatible client path
+- stripped the `github-copilot/` prefix before sending the request upstream
+- applied Copilot-specific headers
+- switched `gpt-5.x` requests to `max_completion_tokens`
+
+### 3. User-facing CLI and TUI
+
+Primary file:
+
+- [crates/claw-cli/src/main.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/claw-cli/src/main.rs)
+
+Implemented pieces:
+
+- `claw login-github-copilot`
+- `claw logout-github-copilot`
+- `copilot` alias for `github-copilot/gpt-5.4`
+- `copilot-4o` alias for `github-copilot/gpt-4o`
+- persisted startup default after successful Copilot login
+- startup banner now shows when GitHub Copilot was selected as the login default
+- `/model` now shows:
+  - current model
+  - quick picks
+  - detected available Copilot models
+  - detected unavailable Copilot models
+
+### 4. Subagents
+
+Primary file:
+
+- [crates/tools/src/lib.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/tools/src/lib.rs)
+
+Implemented pieces:
+
+- the `Agent` tool now inherits `startupPreferences.default_model` when no explicit subagent model is passed
+- this keeps delegated work on the same provider path as the main CLI
+
+## Flow Map
+
+```mermaid
+flowchart TD
+    A[User runs claw login-github-copilot] --> B[GitHub device flow]
+    B --> C[Store GitHub token in ~/.claw]
+    C --> D[Exchange for Copilot runtime token]
+    D --> E[Probe account model availability]
+    E --> F[Persist startupPreferences + model availability cache]
+    F --> G[User runs claw]
+    G --> H[CLI chooses startup default model]
+    H --> I[ProviderClient routes to GithubCopilot]
+    I --> J[OpenAI-compatible request with Copilot headers]
+    J --> K[Response rendered in REPL or one-shot prompt]
+```
+
+## What was tested
+
+### Core compatibility
+
+- `cargo test -p api -p claw-cli -p tools`
+- `./target/debug/claw --model github-copilot/gpt-4o --output-format text prompt "reply with exactly: ok"`
+- `./target/debug/claw --model github-copilot/gpt-5.4 --output-format text prompt "reply with exactly: ok"`
+
+### Startup default UX
+
+- `./target/debug/claw login-github-copilot`
+- `./target/debug/claw`
+- `./target/debug/claw --output-format text prompt "reply with exactly: startup-default-ok"`
+
+### Model availability detection on the current account
+
+Detected available:
+
+- `github-copilot/claude-sonnet-4.6`
+- `github-copilot/claude-sonnet-4.5`
+- `github-copilot/gpt-4o`
+- `github-copilot/gpt-4.1`
+- `github-copilot/gpt-5.4`
+
+Detected unavailable:
+
+- `github-copilot/gpt-4.1-mini`
+- `github-copilot/gpt-4.1-nano`
+- `github-copilot/o1`
+- `github-copilot/o1-mini`
+- `github-copilot/o3-mini`
+
+### Subagent inheritance
+
+- unit test verifies Agent tool inherits startup default model
+- real smoke check verified newly spawned agent manifests now use `github-copilot/gpt-5.4` instead of `opus`
+
+## Operational note
+
+Background subagents created from a short-lived one-shot CLI invocation can outlive the parent process only if the parent process remains alive long enough to supervise them. The intended user path for interactive delegated work remains the REPL/TUI session.
+
+That note is separate from provider inheritance:
+
+- the provider mismatch bug is fixed
+- subagents now inherit the Copilot-backed default model correctly
+
+## What was intentionally not changed
+
+- the original `claw login` flow
+- existing Anthropic/xAI/OpenAI behavior
+- explicit `--model` overrides
+- `/model` session overrides
+- the overall config architecture
+
+## Summary for reviewers
+
+This change set adds GitHub Copilot as a natural, additive provider layer rather than a forked runtime path.
+
+The key design choices were:
+
+- use native `~/.claw` storage first
+- keep `~/.openclaw` fallback optional
+- reuse the existing provider and OpenAI-compatible machinery where possible
+- expose real account availability to the user
+- keep delegation aligned with the same default model the main CLI is using

--- a/rust/docs/github-copilot-compat.md
+++ b/rust/docs/github-copilot-compat.md
@@ -53,8 +53,8 @@ mindmap
 
 Files involved:
 
-- [crates/api/src/providers/github_copilot.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/api/src/providers/github_copilot.rs)
-- [crates/runtime/src/oauth.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/runtime/src/oauth.rs)
+- [crates/api/src/providers/github_copilot.rs](../crates/api/src/providers/github_copilot.rs)
+- [crates/runtime/src/oauth.rs](../crates/runtime/src/oauth.rs)
 
 Implemented pieces:
 
@@ -75,9 +75,9 @@ Credential store keys introduced:
 
 Files involved:
 
-- [crates/api/src/providers/mod.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/api/src/providers/mod.rs)
-- [crates/api/src/client.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/api/src/client.rs)
-- [crates/api/src/providers/openai_compat.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/api/src/providers/openai_compat.rs)
+- [crates/api/src/providers/mod.rs](../crates/api/src/providers/mod.rs)
+- [crates/api/src/client.rs](../crates/api/src/client.rs)
+- [crates/api/src/providers/openai_compat.rs](../crates/api/src/providers/openai_compat.rs)
 
 Implemented pieces:
 
@@ -92,7 +92,7 @@ Implemented pieces:
 
 Primary file:
 
-- [crates/claw-cli/src/main.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/claw-cli/src/main.rs)
+- [crates/claw-cli/src/main.rs](../crates/claw-cli/src/main.rs)
 
 Implemented pieces:
 
@@ -112,7 +112,7 @@ Implemented pieces:
 
 Primary file:
 
-- [crates/tools/src/lib.rs](/Users/cosmophonix/claudecoderust/theanomaly/rust/crates/tools/src/lib.rs)
+- [crates/tools/src/lib.rs](../crates/tools/src/lib.rs)
 
 Implemented pieces:
 

--- a/rust/docs/m1nd-guided-research-report.md
+++ b/rust/docs/m1nd-guided-research-report.md
@@ -1,0 +1,384 @@
+# m1nd-Guided Research Report
+
+This report covers only the research side of the GitHub Copilot rollout work:
+
+- how `m1nd` was used
+- where it accelerated discovery
+- what it confirmed
+- where it had limits
+- what techniques were combined with it
+- what time and search effort it likely saved
+
+This is not product documentation. It is a research and implementation-note appendix for maintainers and reviewers.
+
+## Executive Summary
+
+`m1nd` was useful as a structural accelerator, not as a replacement for direct code reading.
+
+The fastest pattern was:
+
+1. ingest the relevant Rust workspace into `m1nd`
+2. use `m1nd` to identify likely entrypoints, blast radius, and edit surfaces
+3. switch to direct file inspection and live runtime testing for exact behavior
+4. return to `m1nd` when the next question became structural again
+
+That hybrid loop mattered because this work crossed:
+
+- Rust provider routing
+- Rust CLI UX
+- credential persistence
+- background subagent defaults
+- compiled OpenClaw JavaScript behavior
+- real account-level GitHub Copilot model availability
+
+Without structural guidance, this would have turned into a long grep/glob session across two different implementations and several runtime layers.
+
+## Why this matters to reviewers
+
+Yes, this information can be useful to devs, but only if framed correctly.
+
+It is worth sharing because it explains:
+
+- how the change was kept additive instead of invasive
+- why specific entrypoints were chosen
+- how we verified that the main CLI and subagents were using the same provider path
+- why some apparently unrelated areas were inspected and then deliberately left unchanged
+
+It should not be framed as "the project now depends on m1nd".
+
+The correct framing is:
+
+- `m1nd` was used during research and implementation
+- it helped reduce search space and verify structural impact
+- the shipped code does not require `m1nd` to function
+
+## High-Level Mental Map
+
+```mermaid
+mindmap
+  root((m1nd-guided rollout research))
+    Entry points
+      CLI parse_args
+      login flows
+      startup banner
+      /model report
+      Agent tool
+    Provider path
+      ProviderKind
+      ProviderClient
+      OpenAI-compatible transport
+      GitHub Copilot runtime auth
+    Persistence
+      ~/.claw credentials
+      runtime token cache
+      startup preference
+      model availability cache
+    External reference
+      OpenClaw GitHub Copilot plugin
+      device-flow implementation
+      runtime token exchange
+      dynamic base URL
+    Verification
+      cargo tests
+      one-shot prompt execution
+      login smoke test
+      model availability probing
+      subagent manifest inspection
+```
+
+## Research Questions
+
+The research loop was driven by these questions:
+
+1. Where does the Rust CLI decide which provider to use?
+2. Where does the Rust CLI currently persist auth and startup choices?
+3. How does OpenClaw implement GitHub Copilot login and runtime token exchange?
+4. What is the minimal additive seam to bring Copilot into the Rust CLI?
+5. After the main CLI works, do subagents still silently fall back to Anthropic?
+6. What should a normal user see in the UX once Copilot is active?
+
+## What m1nd was used for
+
+### 1. Fast surgical context on exact edit surfaces
+
+`m1nd.surgical_context_v2` was used on the main Rust files involved in:
+
+- provider routing
+- CLI startup behavior
+- OAuth/persistence
+- tool runtime behavior
+
+Observed examples:
+
+- `crates/api/src/providers/mod.rs` context returned in about `0.62 ms`
+- `crates/claw-cli/src/main.rs` context returned in about `0.90 ms`
+
+That is the kind of lookup that normally turns into multiple manual file opens plus grep hops.
+
+### 2. Confirming architectural hotspots
+
+`m1nd.search` and `m1nd.impact` were used to confirm that the highest-risk surfaces really were:
+
+- `crates/api/src/providers/mod.rs`
+- `crates/api/src/client.rs`
+- `crates/claw-cli/src/main.rs`
+- `crates/runtime/src/oauth.rs`
+- `crates/tools/src/lib.rs`
+
+This mattered because the change initially looked like “just add a provider”, but the real impact crossed:
+
+- provider detection
+- request translation
+- login UX
+- startup defaults
+- subagent inheritance
+
+### 3. Separating core fix from side effects
+
+`m1nd` helped identify that the rollout had two distinct problems:
+
+- main CLI provider compatibility
+- subagent lifecycle/provider inheritance
+
+This was useful because once the main CLI was working, the remaining subagent failure logs could have been misread as "Copilot still broken".
+
+Instead, the investigation made it clear that:
+
+- the main provider path was fixed
+- the `Agent` tool still had a hardcoded Anthropic default
+
+That made the subagent fix small and precise.
+
+### 4. Surfacing when not to trust the first answer
+
+Some broad `m1nd` searches returned little or no actionable result.
+
+That was still useful.
+
+It forced the investigation into a better pattern:
+
+- use `m1nd` for structure
+- use `rg`, `sed`, and direct file reads for exact implementation details
+
+That avoided a common failure mode where a graph/semantic tool is treated like a magical oracle.
+
+## Concrete m1nd-assisted findings
+
+### Provider routing
+
+`m1nd` helped confirm that the provider seam was centered on:
+
+- `ProviderKind`
+- provider metadata resolution
+- provider client construction
+
+That directly led to the decision to add:
+
+- `ProviderKind::GithubCopilot`
+- `github-copilot/<model-id>` model refs
+- a provider path that reuses the OpenAI-compatible client instead of inventing a separate transport stack
+
+### CLI UX
+
+`m1nd` helped isolate the smallest UX seam:
+
+- `parse_args`
+- startup banner
+- `/model`
+- login command
+
+That made it possible to implement:
+
+- `login-github-copilot`
+- persisted startup default
+- startup banner source note
+- model aliases
+- model availability section in `/model`
+
+without introducing a second configuration system.
+
+### Subagents
+
+`m1nd` was useful in showing that the `Agent` tool had its own default model path.
+
+That led to the key fix:
+
+- subagents now inherit the same persisted startup default model as the main CLI when no explicit subagent model is passed
+
+This directly addressed the log pattern where:
+
+- the main CLI was on Copilot
+- the subagent still launched as `opus`
+
+## Techniques that saved hours beyond raw grep/glob
+
+This work did not rely on a single technique.
+
+The speed came from combining several:
+
+### Structural narrowing with `m1nd`
+
+Used for:
+
+- entrypoint discovery
+- blast-radius checks
+- edit-surface narrowing
+- “what is the next smallest place to change?” decisions
+
+### `rg` as the exactness layer
+
+Used after `m1nd` to:
+
+- confirm exact symbols
+- inspect hardcoded defaults
+- locate usage sites and tests
+- inspect compiled OpenClaw artifacts quickly
+
+### Live provider smoke tests
+
+Instead of assuming compatibility from code shape, real prompts were run against:
+
+- `github-copilot/gpt-4o`
+- `github-copilot/gpt-5.4`
+- additional account-dependent Copilot model IDs
+
+This caught subtle provider differences such as:
+
+- unsupported `max_tokens` vs `max_completion_tokens`
+- model IDs accepted by the code but not by the current account
+
+### Manifest and cache inspection
+
+Instead of guessing whether the right model path was being used, the investigation read:
+
+- `.claw-agents/*.json`
+- `~/.claw/credentials.json`
+
+That made it possible to prove:
+
+- which model the subagent actually launched with
+- which models were detected as available on the account
+
+### Sequential verification
+
+The rollout was verified in layers:
+
+1. unit tests
+2. provider smoke tests
+3. login flow
+4. startup default
+5. model availability cache
+6. subagent inheritance
+
+That sequence prevented “it works in one place, breaks in another” surprises.
+
+## Observed timings
+
+These are observed timings from the actual work where the tool returned them directly.
+
+### m1nd timings observed
+
+- `m1nd.ingest` on the Rust workspace: about `425.56 ms`
+- `m1nd.layers` on the Rust workspace: about `18.16 ms`
+- `m1nd.surgical_context_v2` on targeted Rust files: about `0.62 ms` and `0.90 ms`
+- `m1nd.search` on `ProviderKind`: about `13.25 s`
+- `m1nd.search` on `resolveCopilotApiToken` in OpenClaw dist: about `1.47 s`
+- `m1nd.search` on `githubCopilotLoginCommand`: about `334.65 ms`
+
+### Practical interpretation
+
+The sub-second context fetches were especially valuable because they replaced repeated manual:
+
+- `rg`
+- `sed`
+- “open neighbor file”
+- “grep callers”
+- “check tests”
+
+loops on the same surfaces.
+
+## Estimated time saved
+
+This section is intentionally marked as an estimate, not a measured benchmark.
+
+### Conservative estimate
+
+Estimated search and orientation time saved: **1.5 to 3.5 hours**
+
+Why that estimate is reasonable:
+
+- the work crossed both Rust and compiled OpenClaw JavaScript
+- it involved auth, runtime transport, CLI UX, and subagents
+- a pure grep/glob workflow would have required repeated manual reconstruction of:
+  - provider routing
+  - startup-default behavior
+  - subagent model inheritance
+  - Copilot-specific request quirks
+
+### What specifically was avoided
+
+Likely avoided:
+
+- dozens of extra `rg` passes across compiled JS bundles
+- repeated manual caller/callee tracing for provider selection
+- trial-and-error edits in the wrong layer
+- overbroad changes in config handling
+
+## Where m1nd was less useful
+
+This is important for credibility.
+
+`m1nd` was not ideal for:
+
+- very broad fuzzy questions with no concrete file or symbol target
+- proving exact request payload compatibility with a live external provider
+- replacing direct reading of compiled OpenClaw JavaScript when exact constants mattered
+
+That is why the workflow remained hybrid.
+
+## What this tells maintainers
+
+The biggest practical lesson is not “use m1nd everywhere”.
+
+It is:
+
+- use `m1nd` to narrow
+- use direct reads to confirm
+- use live runtime tests to validate
+
+That combination kept the rollout additive and reviewable.
+
+## Why this is useful to mention in a PR
+
+Yes, I think this information can help the devs if included as an implementation note or linked appendix.
+
+Why it can help:
+
+- it explains why the patch stayed small in the right places
+- it documents the research method used to avoid architectural drift
+- it shows that model availability and subagent inheritance were intentionally validated, not assumed
+
+Why it should not be front-and-center in the PR summary:
+
+- reviewers mainly care about behavior, risk, and tests
+- tooling/process notes are best as an implementation note or linked appendix
+
+## Suggested PR wording
+
+If maintainers want a short mention, this is a good level:
+
+> Implementation note: `m1nd` was used during research to map provider routing, CLI entrypoints, and subagent inheritance so the Copilot rollout could stay additive rather than invasive.
+
+If maintainers want a fuller note, link this document rather than stuffing the main PR body.
+
+## Final assessment
+
+`m1nd` materially helped with this rollout.
+
+Not because it replaced engineering judgment, but because it reduced the amount of blind spelunking needed to:
+
+- find the right seams
+- avoid changing the wrong layer
+- keep the patch consistent across main CLI and subagent behavior
+
+That is the highest-value role it played in this work.

--- a/rust/docs/m1nd-mcp-post-implementation-report.md
+++ b/rust/docs/m1nd-mcp-post-implementation-report.md
@@ -1,4 +1,4 @@
-# m1nd-Guided Research Report
+# m1nd MCP Post-Implementation Report
 
 This report covers only the research side of the GitHub Copilot rollout work:
 
@@ -56,7 +56,7 @@ The correct framing is:
 
 ```mermaid
 mindmap
-  root((m1nd-guided rollout research))
+  root((m1nd MCP post-implementation))
     Entry points
       CLI parse_args
       login flows


### PR DESCRIPTION
## Summary
- add a native GitHub Copilot provider path to the Rust CLI/runtime
- support GitHub device login plus native `~/.claw` credential/cache storage
- keep `~/.openclaw` as an optional local compatibility fallback instead of a hard dependency
- route prompt/REPL execution through the provider-aware client so Copilot models work in the main CLI flow
- normalize Copilot request payloads and headers, including `github-copilot/*` model ids and `gpt-5.x` token field handling
- make `claw` default to Copilot after login, show that choice in the startup UX, and surface detected available/unavailable Copilot models in `/model`
- make subagents inherit the active default model instead of falling back to a hardcoded Anthropic default

## Testing
- `cargo test -p api -p claw-cli -p tools`
- `./target/debug/claw login-github-copilot`
- `./target/debug/claw`
- `./target/debug/claw --output-format text prompt "reply with exactly: startup-default-ok"`
- `./target/debug/claw --model github-copilot/gpt-4o --output-format text prompt "reply with exactly: ok"`
- `./target/debug/claw --model github-copilot/gpt-5.4 --output-format text prompt "reply with exactly: ok"`
- `cargo test -p tools agent_persists_handoff_metadata --quiet`

## Account-validated Copilot models
Detected as available on the tested account:
- `github-copilot/claude-sonnet-4.6`
- `github-copilot/claude-sonnet-4.5`
- `github-copilot/gpt-4o`
- `github-copilot/gpt-4.1`
- `github-copilot/gpt-5.4`

Detected as unavailable on the tested account:
- `github-copilot/gpt-4.1-mini`
- `github-copilot/gpt-4.1-nano`
- `github-copilot/o1`
- `github-copilot/o1-mini`
- `github-copilot/o3-mini`

## Handoff docs
- `rust/docs/github-copilot-compat.md`
- `rust/docs/m1nd-mcp-post-implementation-report.md`

## Implementation notes
- this work used `m1nd` during research/implementation to map provider routing, startup UX seams, and subagent inheritance so the rollout could stay additive instead of invasive
- the shipped code does not depend on `m1nd` at runtime

## Notes
- the existing Claw OAuth flow and Anthropic/xAI/OpenAI provider paths remain intact
- the OpenClaw fallback is only a compatibility layer for machines that already have that state available
- the main remaining nuance is operational: short-lived one-shot processes can still make background subagent completion harder to observe, but provider inheritance itself is fixed
